### PR TITLE
perf: reduce heap allocation and improve overall performence

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ func main() {
     queue := worker.BindQueue()
 
     // Add jobs to the queue
-    job1 := queue.Add("Hello")
-    job2 := queue.Add("World")
+    job1, _ := queue.Add("Hello")
+    job2, _ := queue.Add("World")
 
     // Get results (Result() returns both value and error)
     result1, err1 := job1.Result()

--- a/bench_test.go
+++ b/bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkQueue_Operations(b *testing.B) {
 		// Create a worker with the double function
 		worker := NewWorker(func(data int) (int, error) {
 			return data * 2, nil
-		}, 4)
+		})
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
 		defer q.WaitAndClose()

--- a/bench_test.go
+++ b/bench_test.go
@@ -46,10 +46,7 @@ func BenchmarkQueue_Operations(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			results, _ := q.AddAll(data).Results()
-			for range results {
-				// drain the channel
-			}
+			q.AddAll(data).Wait()
 		}
 	})
 }
@@ -88,10 +85,7 @@ func BenchmarkQueue_ParallelOperations(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				results, _ := q.AddAll(data).Results()
-				for range results {
-					// drain the channel
-				}
+				q.AddAll(data).Wait()
 			}
 		})
 	})
@@ -128,10 +122,7 @@ func BenchmarkPriorityQueue_Operations(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			results, _ := q.AddAll(data).Results()
-			for range results {
-				// drain the channel
-			}
+			q.AddAll(data).Wait()
 		}
 	})
 }
@@ -170,11 +161,7 @@ func BenchmarkPriorityQueue_ParallelOperations(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				if results, err := q.AddAll(data).Results(); err == nil {
-					for range results {
-						// drain the channel
-					}
-				}
+				q.AddAll(data).Wait()
 			}
 		})
 	})
@@ -211,11 +198,7 @@ func BenchmarkVoidWorker_Operations(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if results, err := q.AddAll(data).Results(); err == nil {
-				for range results {
-					// drain the channel
-				}
-			}
+			q.AddAll(data).Wait()
 		}
 	})
 }
@@ -254,10 +237,7 @@ func BenchmarkVoidWorker_ParallelOperations(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				results, _ := q.AddAll(data).Results()
-				for range results {
-					// drain the channel
-				}
+				q.AddAll(data).Wait()
 			}
 		})
 	})

--- a/config.go
+++ b/config.go
@@ -14,7 +14,7 @@ type configs struct {
 	CleanupCacheInterval     time.Duration
 	JobIdGenerator           func() string
 	IdleWorkerExpiryDuration time.Duration
-	MinIdleWorkerRatio       uint16
+	MinIdleWorkerRatio       uint8
 }
 
 func newConfig() configs {
@@ -58,7 +58,7 @@ func WithIdleWorkerExpiryDuration(duration time.Duration) ConfigFunc {
 // Example: 20 means keep 20% of the concurrency level as idle workers.
 // The actual number of idle workers will be calculated as: concurrency * percentage / 100.
 // The percentage must be between 1 and 100. Values outside this range will be clamped.
-func WithMinIdleWorkerRatio(percentage uint16) ConfigFunc {
+func WithMinIdleWorkerRatio(percentage uint8) ConfigFunc {
 	// Clamp percentage between 1 and 100
 	if percentage == 0 {
 		percentage = 1

--- a/config_test.go
+++ b/config_test.go
@@ -107,9 +107,9 @@ func TestConfig(t *testing.T) {
 
 		t.Run("WithMinIdleWorkerRatio", func(t *testing.T) {
 			tests := []struct {
-				name         string
-				percentage   uint16
-				expectedRatio uint16
+				name          string
+				percentage    uint8
+				expectedRatio uint8
 			}{
 				{"Zero percentage should be clamped to 1", 0, 1},
 				{"Value above 100 should be clamped to 100", 150, 100},

--- a/examples/void-worker/main.go
+++ b/examples/void-worker/main.go
@@ -8,17 +8,16 @@ import (
 )
 
 func main() {
-	start := time.Now()
-	defer func() {
-		fmt.Println("Time taken:", time.Since(start))
-	}()
-
 	w := varmq.NewVoidWorker(func(data int) {
 		fmt.Printf("Processing: %d\n", data)
 		time.Sleep(1 * time.Second)
 	}, 100)
 
 	q := w.BindQueue()
+	start := time.Now()
+	defer func() {
+		fmt.Println("Time taken:", time.Since(start))
+	}()
 	defer q.WaitAndClose()
 	defer fmt.Println("Added jobs")
 

--- a/group_job.go
+++ b/group_job.go
@@ -57,10 +57,7 @@ func (gj *groupJob[T, R]) Results() (<-chan Result[R], error) {
 }
 
 func (gj *groupJob[T, R]) Wait() {
-	for range gj.done {
-		close(gj.done)
-		return
-	}
+	<-gj.done
 }
 
 func (gj *groupJob[T, R]) Len() int {

--- a/group_job_test.go
+++ b/group_job_test.go
@@ -18,7 +18,7 @@ func TestGroupJob(t *testing.T) {
 		// Validate group job structure
 		assert.NotNil(gj, "group job should not be nil")
 		assert.NotNil(gj.job, "underlying job should not be nil")
-		assert.NotNil(gj.wg, "wait group should not be nil")
+		assert.NotNil(gj.ctrl, "group control should not be nil")
 		assert.NotNil(gj.resultChannel, "result channel should be initialized")
 	})
 
@@ -51,7 +51,7 @@ func TestGroupJob(t *testing.T) {
 		assert.Equal(generateGroupId(jobId), newJob.ID(), "job ID should have group prefix")
 		assert.Equal(jobData, newJob.Data(), "job data should match")
 		assert.Equal(gj.resultChannel, newJob.resultChannel, "result channel should be shared with the group")
-		assert.Equal(gj.wg, newJob.wg, "wait group should be shared with the group")
+		assert.Equal(gj.ctrl, newJob.ctrl, "group control should be shared with the group")
 	})
 
 	t.Run("closing a group job", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestGroupJob(t *testing.T) {
 
 		// Manually reduce the wait group count to match our single Close() call
 		// This prevents the wait group from blocking indefinitely
-		gj.wg.Add(-bufferSize + 1)
+		gj.ctrl.AddWait(-bufferSize + 1)
 
 		assert := assert.New(t)
 
@@ -83,7 +83,7 @@ func TestGroupJob(t *testing.T) {
 		gj := newGroupJob[string, int](bufferSize)
 
 		// Reduce wait group count to prevent deadlock when testing
-		gj.wg.Add(-int(bufferSize))
+		gj.ctrl.AddWait(-int(bufferSize))
 
 		assert := assert.New(t)
 

--- a/group_job_test.go
+++ b/group_job_test.go
@@ -2,7 +2,9 @@ package varmq
 
 import (
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,9 +19,10 @@ func TestGroupJob(t *testing.T) {
 
 		// Validate group job structure
 		assert.NotNil(gj, "group job should not be nil")
-		assert.NotNil(gj.job, "underlying job should not be nil")
-		assert.NotNil(gj.ctrl, "group control should not be nil")
 		assert.NotNil(gj.resultChannel, "result channel should be initialized")
+		assert.NotNil(gj.done, "done channel should be initialized")
+		assert.NotNil(gj.len, "atomic counter should be initialized")
+		assert.Equal(bufferSize, gj.Len(), "initial length should match buffer size")
 	})
 
 	t.Run("generate group ID", func(t *testing.T) {
@@ -51,25 +54,127 @@ func TestGroupJob(t *testing.T) {
 		assert.Equal(generateGroupId(jobId), newJob.ID(), "job ID should have group prefix")
 		assert.Equal(jobData, newJob.Data(), "job data should match")
 		assert.Equal(gj.resultChannel, newJob.resultChannel, "result channel should be shared with the group")
-		assert.Equal(gj.ctrl, newJob.ctrl, "group control should be shared with the group")
+		assert.Equal(gj.done, newJob.done, "done channel should be shared with the group")
+		assert.Equal(gj.len, newJob.len, "length counter should be shared with the group")
+	})
+
+	t.Run("getting results from a group job", func(t *testing.T) {
+		// Create a group job
+		bufferSize := 2
+		gj := newGroupJob[string, int](bufferSize)
+
+		assert := assert.New(t)
+
+		// Add a result to the channel
+		result := Result[int]{Data: 42, Err: nil}
+		gj.resultChannel.Send(result)
+
+		// Get results
+		ch, err := gj.Results()
+		assert.Nil(err, "getting results should not fail")
+		assert.NotNil(ch, "result channel should not be nil")
+
+		// Check if the result can be read
+		select {
+		case r := <-ch:
+			assert.Equal(result, r, "result value should match")
+		case <-time.After(time.Millisecond * 100):
+			t.Fatal("timeout waiting for result")
+		}
+	})
+
+	t.Run("wait for group job completion", func(t *testing.T) {
+		// Create a group job
+		bufferSize := 1
+		gj := newGroupJob[string, int](bufferSize)
+
+		// Setup done channel to simulate completion
+		go func() {
+			time.Sleep(time.Millisecond * 50)
+			close(gj.done)
+		}()
+
+		// Create a wait group to synchronize test completion
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Start waiting for job completion in a goroutine
+		go func() {
+			defer wg.Done()
+			gj.Wait()
+		}()
+
+		// Wait with timeout
+		waitCh := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(waitCh)
+		}()
+
+		select {
+		case <-waitCh:
+			// Success, wait completed
+		case <-time.After(time.Millisecond * 500):
+			t.Fatal("timeout waiting for job completion")
+		}
+	})
+
+	t.Run("getting length of a group job", func(t *testing.T) {
+		// Create a group job with buffer size 5
+		bufferSize := 5
+		gj := newGroupJob[string, int](bufferSize)
+
+		assert := assert.New(t)
+
+		// Verify initial length
+		assert.Equal(bufferSize, gj.Len(), "initial length should match buffer size")
+
+		// Simulate jobs completing by decrementing counter
+		gj.len.Add(^uint32(0)) // Subtract 1
+		assert.Equal(bufferSize-1, gj.Len(), "length should be decremented after a job completes")
+	})
+
+	t.Run("draining a group job", func(t *testing.T) {
+		// Create a group job
+		bufferSize := 3
+		gj := newGroupJob[string, int](bufferSize)
+
+		assert := assert.New(t)
+
+		// Add results to drain
+		gj.resultChannel.Send(Result[int]{Data: 1, Err: nil})
+		gj.resultChannel.Send(Result[int]{Data: 2, Err: nil})
+
+		// Drain the results
+		err := gj.Drain()
+		assert.Nil(err, "draining should not fail")
+
+		// After draining, we should be able to add more results
+		// (This verifies the drain is working and not blocking)
+		gj.resultChannel.Send(Result[int]{Data: 3, Err: nil})
 	})
 
 	t.Run("closing a group job", func(t *testing.T) {
 		// Create a group job with small buffer to avoid wait group blocking
-		bufferSize := 1
+		bufferSize := 2
 		gj := newGroupJob[string, int](bufferSize)
-
-		// Manually reduce the wait group count to match our single Close() call
-		// This prevents the wait group from blocking indefinitely
-		gj.ctrl.AddWait(-bufferSize + 1)
 
 		assert := assert.New(t)
 
-		// Close the job
+		// Close the job - this should decrement the counter but not close channels yet
 		err := gj.close()
 		assert.Nil(err, "closing group job should not fail")
 		assert.Equal("Closed", gj.Status(), "job status should be 'Closed' after close")
 		assert.True(gj.IsClosed(), "job should be marked as closed")
+		assert.Equal(bufferSize-1, gj.Len(), "length should be decremented after close")
+
+		// Close another job from the group
+		jobData := "test data"
+		jobId := "test-job"
+		newJob := gj.NewJob(jobData, jobConfigs{Id: jobId})
+		err = newJob.close()
+		assert.Nil(err, "closing second job should not fail")
+		assert.Equal(bufferSize-2, gj.Len(), "length should be decremented again")
 
 		// Attempting to close again should fail
 		err = gj.close()
@@ -77,13 +182,41 @@ func TestGroupJob(t *testing.T) {
 		assert.Contains(err.Error(), "already closed", "error message should indicate job is already closed")
 	})
 
+	t.Run("closing all jobs in a group", func(t *testing.T) {
+		// Create a group job with buffer size 2
+		bufferSize := 2
+		gj := newGroupJob[string, int](bufferSize)
+
+		// Create a second job in the group
+		job2 := gj.NewJob("test data", jobConfigs{Id: "test-job"})
+
+		assert := assert.New(t)
+
+		// Close both jobs, which should close the group
+		_ = gj.close()
+		_ = job2.close()
+
+		// Length should be 0 now
+		assert.Equal(0, gj.Len(), "length should be 0 after all jobs are closed")
+
+		// Check if the channels are closed by trying to add a result
+		// This should panic, so we recover from it
+		didPanic := false
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					didPanic = true
+				}
+			}()
+			gj.resultChannel.Send(Result[int]{Data: 1, Err: nil})
+		}()
+		assert.True(didPanic, "adding to a closed channel should panic")
+	})
+
 	t.Run("job status transitions in a group job", func(t *testing.T) {
 		// Create a new group job
 		bufferSize := 1
 		gj := newGroupJob[string, int](bufferSize)
-
-		// Reduce wait group count to prevent deadlock when testing
-		gj.ctrl.AddWait(-int(bufferSize))
 
 		assert := assert.New(t)
 

--- a/job.go
+++ b/job.go
@@ -27,7 +27,7 @@ type job[T, R any] struct {
 	Input         T
 	status        atomic.Uint32
 	Output        *Result[R]
-	resultChannel *resultChannel[R]
+	resultChannel resultChannel[R]
 	queue         IBaseQueue
 	ackId         string
 }

--- a/job.go
+++ b/job.go
@@ -26,7 +26,7 @@ type job[T, R any] struct {
 	id            string
 	Input         T
 	status        atomic.Uint32
-	Output        *Result[R]
+	Output        Result[R]
 	resultChannel resultChannel[R]
 	queue         IBaseQueue
 	ackId         string
@@ -34,10 +34,10 @@ type job[T, R any] struct {
 
 // jobView represents a view of a job's state for serialization.
 type jobView[T, R any] struct {
-	Id     string     `json:"id"`
-	Status string     `json:"status"`
-	Input  T          `json:"input"`
-	Output *Result[R] `json:"output,omitempty"`
+	Id     string    `json:"id"`
+	Status string    `json:"status"`
+	Input  T         `json:"input"`
+	Output Result[R] `json:"output,omitempty"`
 }
 
 type Job interface {
@@ -72,7 +72,7 @@ func newJob[T, R any](data T, configs jobConfigs) *job[T, R] {
 		Input:         data,
 		resultChannel: newResultChannel[R](1),
 		status:        atomic.Uint32{},
-		Output:        new(Result[R]),
+		Output:        Result[R]{},
 	}
 }
 
@@ -132,14 +132,14 @@ func (j *job[T, R]) ChangeStatus(s status) {
 // SaveAndSendResult saves the result and sends it to the job's result channel.
 func (j *job[T, R]) SaveAndSendResult(result R) {
 	r := Result[R]{JobId: j.id, Data: result}
-	j.Output = &r
+	j.Output = r
 	j.resultChannel.Send(r)
 }
 
 // SaveAndSendError sends an error to the job's result channel.
 func (j *job[T, R]) SaveAndSendError(err error) {
 	r := Result[R]{JobId: j.id, Err: err}
-	j.Output = &r
+	j.Output = r
 	j.resultChannel.Send(r)
 }
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -76,7 +76,7 @@ func TestQueue(t *testing.T) {
 		pending := queue.NumPending()
 		assert.Equal(t, 5, pending, "Queue should have five pending jobs")
 		assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have five items")
-		assert.Equal(t, pending, groupJob.Len(), "Internal Queue should have five items")
+		assert.Equal(t, pending, groupJob.Len(), "Group job should have five items")
 
 		err := worker.start()
 		assert.Nil(t, err, "Worker should start successfully")

--- a/result.go
+++ b/result.go
@@ -19,6 +19,8 @@ type EnqueuedJob[R any] interface {
 type EnqueuedGroupJob[T any] interface {
 	// Len returns the number of jobs in the group.
 	Len() int
+	// Wait blocks until all jobs in the group are completed.
+	Wait()
 	// Drain discards the job's result and error values asynchronously.
 	Drain() error
 	// Results returns a channel that will receive the results of the group

--- a/result_channel.go
+++ b/result_channel.go
@@ -21,7 +21,7 @@ func newResultChannel[R any](cap int) resultChannel[R] {
 }
 
 func (rc *resultChannel[R]) Read() (<-chan Result[R], error) {
-	if rc.consumed.Load().(bool) {
+	if rc.consumed.Load() != nil {
 		return nil, errors.New("result channel has already been consumed")
 	}
 

--- a/result_channel.go
+++ b/result_channel.go
@@ -14,8 +14,8 @@ type resultChannel[R any] struct {
 }
 
 // newResultChannel creates a new resultChannel with the specified buffer size.
-func newResultChannel[R any](cap int) *resultChannel[R] {
-	return &resultChannel[R]{
+func newResultChannel[R any](cap int) resultChannel[R] {
+	return resultChannel[R]{
 		ch: make(chan Result[R], cap),
 	}
 }


### PR DESCRIPTION
- **Refactor**
  - Simplified internal handling of job results and result channels for improved efficiency.
  - Updated benchmark worker creation to use default concurrency settings.
  - Enhanced group job synchronization with unified control for better job counting and completion tracking.
  - Improved timing measurement placement in example usage.
  - Adjusted configuration field types for consistency.
- **Documentation**
  - Clarified example usage by explicitly handling errors in queue operations.

### Old bench
```
BenchmarkQueue_Operations/Add-4               	  806361	      1384 ns/op	     384 B/op	       8 allocs/op
BenchmarkQueue_Operations/AddAll-4            	      1194   1003741 ns/op	  243343 B/op	    7008 allocs/op
```

### New bench
```
BenchmarkQueue_Operations/Add-4               	  928090	      1258 ns/op	     320 B/op	       5 allocs/op
BenchmarkQueue_Operations/AddAll-4            	    1416	    833844 ns/op	  235428 B/op	    5005 allocs/op
```