### PR TITLE
refactor: moved wait methods to worker

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkQueue_Operations(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		b.ResetTimer()
 		for j := range b.N {
@@ -43,7 +43,7 @@ func BenchmarkQueue_Operations(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -64,7 +64,7 @@ func BenchmarkPriorityQueue_Operations(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		b.ResetTimer()
 		for i := range b.N {
@@ -79,7 +79,7 @@ func BenchmarkPriorityQueue_Operations(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -100,7 +100,7 @@ func BenchmarkErrWorker_Operations(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		b.ResetTimer()
 		for j := range b.N {
@@ -115,7 +115,7 @@ func BenchmarkErrWorker_Operations(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -136,7 +136,7 @@ func BenchmarkErrPriorityQueue_Operations(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		b.ResetTimer()
 		for i := range b.N {
@@ -151,7 +151,7 @@ func BenchmarkErrPriorityQueue_Operations(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -172,7 +172,7 @@ func BenchmarkResultWorker_Operations(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		b.ResetTimer()
 		for j := range b.N {
@@ -187,7 +187,7 @@ func BenchmarkResultWorker_Operations(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -208,7 +208,7 @@ func BenchmarkResultPriorityQueue_Operations(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		b.ResetTimer()
 		for i := range b.N {
@@ -223,7 +223,7 @@ func BenchmarkResultPriorityQueue_Operations(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer q.WaitAndClose()
+		defer worker.WaitAndStop()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {

--- a/examples/idle-wokers/main.go
+++ b/examples/idle-wokers/main.go
@@ -34,7 +34,7 @@ retry:
 		q.Add(i)
 	}
 	fmt.Println("Added jobs")
-	q.WaitUntilFinished()
+	w.WaitUntilFinished()
 
 	goto retry
 }

--- a/examples/tune-worker/main.go
+++ b/examples/tune-worker/main.go
@@ -54,7 +54,7 @@ retry:
 	}
 
 	fmt.Println("Added jobs")
-	q.WaitUntilFinished()
+	w.WaitUntilFinished()
 	time.Sleep(5 * time.Second)
 	goto retry
 }

--- a/examples/worker/main.go
+++ b/examples/worker/main.go
@@ -13,7 +13,7 @@ func main() {
 		time.Sleep(1 * time.Second)
 	})
 	q := w.BindQueue()
-	defer q.WaitUntilFinished()
+	defer w.WaitUntilFinished()
 
 	for i := range 100 {
 		q.Add(i)

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func NewErrWorker[T any](wf func(j Job[T]) error, config ...any) IErrWorkerBinde
 		var panicErr error
 		var err error
 
-		panicErr = utils.WithSafe("worker", func() {
+		panicErr = utils.WithSafe("err-worker", func() {
 			err = wf(ij)
 		})
 
@@ -81,7 +81,7 @@ func NewResultWorker[T, R any](wf func(j Job[T]) (R, error), config ...any) IRes
 		var panicErr error
 		var err error
 
-		panicErr = utils.WithSafe("worker", func() {
+		panicErr = utils.WithSafe("result-worker", func() {
 			result, e := wf(ij)
 			if e != nil {
 				err = e

--- a/persistent.go
+++ b/persistent.go
@@ -2,7 +2,10 @@ package varmq
 
 // PersistentQueue is an interface that extends Queue to support persistent job operations
 type PersistentQueue[T any] interface {
-	IExternalQueue
+	IExternalBaseQueue
+
+	// Worker returns the bound worker.
+	Worker() Worker
 
 	// Add adds a job with the given data to the persistent queue
 	// It returns true if the job was added successfully
@@ -18,8 +21,8 @@ type persistentQueue[T any] struct {
 func newPersistentQueue[T any](w *worker[T, iJob[T]], pq IPersistentQueue) PersistentQueue[T] {
 	w.setQueue(pq)
 	return &persistentQueue[T]{queue: &queue[T]{
-		externalQueue: newExternalQueue(w),
-		internalQueue: pq,
+		externalBaseQueue: newExternalQueue(pq, w),
+		internalQueue:     pq,
 	}}
 }
 

--- a/persistent_priority.go
+++ b/persistent_priority.go
@@ -1,7 +1,7 @@
 package varmq
 
 type PersistentPriorityQueue[T any] interface {
-	IExternalQueue
+	IExternalBaseQueue
 	// Add adds a new Job with the given priority to the queue
 	// It returns true if the job was added successfully
 	Add(data T, priority int, configs ...JobConfigFunc) bool

--- a/priority.go
+++ b/priority.go
@@ -1,12 +1,14 @@
 package varmq
 
 type priorityQueue[T any] struct {
-	*externalQueue
+	*externalBaseQueue
 	internalQueue IPriorityQueue
 }
 
 type PriorityQueue[T any] interface {
-	IExternalQueue
+	IExternalBaseQueue
+	// Worker returns the bound worker.
+	Worker() Worker
 	// Add adds a new Job with the given priority to the queue and returns a EnqueuedJob to handle the job.
 	// Time complexity: O(log n)
 	Add(data T, priority int, configs ...JobConfigFunc) (EnqueuedJob, bool)
@@ -20,8 +22,8 @@ func newPriorityQueue[T any](worker *worker[T, iJob[T]], pq IPriorityQueue) *pri
 	worker.setQueue(pq)
 
 	return &priorityQueue[T]{
-		externalQueue: newExternalQueue(worker),
-		internalQueue: pq,
+		externalBaseQueue: newExternalQueue(pq, worker),
+		internalQueue:     pq,
 	}
 }
 
@@ -58,12 +60,14 @@ func (q *priorityQueue[T]) AddAll(items []Item[T]) EnqueuedGroupJob {
 }
 
 type resultPriorityQueue[T any, R any] struct {
-	*externalQueue
+	*externalBaseQueue
 	internalQueue IPriorityQueue
 }
 
 type ResultPriorityQueue[T, R any] interface {
-	IExternalQueue
+	IExternalBaseQueue
+	// Worker returns the bound worker.
+	Worker() Worker
 	// Add adds a new Job with the given priority to the queue and returns a EnqueuedResultJob to handle the job with result receiving.
 	// Time complexity: O(log n)
 	Add(data T, priority int, configs ...JobConfigFunc) (EnqueuedResultJob[R], bool)
@@ -76,8 +80,8 @@ func newResultPriorityQueue[T, R any](worker *worker[T, iResultJob[T, R]], pq IP
 	worker.setQueue(pq)
 
 	return &resultPriorityQueue[T, R]{
-		externalQueue: newExternalQueue(worker),
-		internalQueue: pq,
+		externalBaseQueue: newExternalQueue(pq, worker),
+		internalQueue:     pq,
 	}
 }
 
@@ -114,12 +118,14 @@ func (q *resultPriorityQueue[T, R]) AddAll(items []Item[T]) EnqueuedResultGroupJ
 }
 
 type errorPriorityQueue[T any] struct {
-	*externalQueue
+	*externalBaseQueue
 	internalQueue IPriorityQueue
 }
 
 type ErrPriorityQueue[T any] interface {
-	IExternalQueue
+	IExternalBaseQueue
+	// Worker returns the bound worker.
+	Worker() Worker
 	// Add adds a new Job with the given priority to the queue and returns a EnqueuedErrJob to handle the job with error receiving.
 	// Time complexity: O(log n)
 	Add(data T, priority int, configs ...JobConfigFunc) (EnqueuedErrJob, bool)
@@ -132,8 +138,8 @@ func newErrorPriorityQueue[T any](worker *worker[T, iErrorJob[T]], pq IPriorityQ
 	worker.setQueue(pq)
 
 	return &errorPriorityQueue[T]{
-		externalQueue: newExternalQueue(worker),
-		internalQueue: pq,
+		externalBaseQueue: newExternalQueue(pq, worker),
+		internalQueue:     pq,
 	}
 }
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -655,29 +655,6 @@ func TestExternalQueue(t *testing.T) {
 		assert.Equal(expectedWorker, actualWorker, "Worker() should return the expected worker instance")
 	})
 
-	t.Run("WaitUntilFinished", func(t *testing.T) {
-		queue, worker, internalQueue := setupBasicQueue()
-		assert := assert.New(t)
-
-		// Start the worker
-		err := worker.start()
-		assert.NoError(err, "Worker should start successfully")
-		defer worker.Stop()
-
-		// Add several jobs
-		for i := range 5 {
-			queue.Add("test-data-" + strconv.Itoa(i))
-		}
-		assert.LessOrEqual(queue.NumPending(), 5, "Queue should have at most five pending jobs")
-
-		// Wait until all jobs are processed
-		queue.WaitUntilFinished()
-
-		// After waiting, should have no pending jobs
-		assert.Equal(0, queue.NumPending(), "Queue should have no pending jobs after WaitUntilFinished")
-		assert.Equal(0, internalQueue.Len(), "Internal queue should be empty after WaitUntilFinished")
-	})
-
 	t.Run("Purge", func(t *testing.T) {
 		queue, _, internalQueue := setupBasicQueue()
 		assert := assert.New(t)
@@ -717,30 +694,5 @@ func TestExternalQueue(t *testing.T) {
 		// After closing, should have no pending jobs and worker should be stopped
 		assert.Equal(0, queue.NumPending(), "Queue should have no pending jobs after Close")
 		assert.Equal(0, internalQueue.Len(), "Internal queue should be empty after Close")
-		assert.True(worker.IsStopped(), "Worker should be stopped after Close")
-	})
-
-	t.Run("WaitAndClose", func(t *testing.T) {
-		queue, worker, internalQueue := setupBasicQueue()
-		assert := assert.New(t)
-
-		// Start the worker
-		err := worker.start()
-		assert.NoError(err, "Worker should start successfully")
-
-		// Add several jobs
-		for i := range 5 {
-			queue.Add("test-data-" + strconv.Itoa(i))
-		}
-		assert.LessOrEqual(queue.NumPending(), 5, "Queue should have at most five pending jobs")
-
-		// Wait and close the queue
-		err = queue.WaitAndClose()
-		assert.NoError(err, "WaitAndClose should not return an error")
-
-		// After waiting and closing, should have no pending jobs and worker should be stopped
-		assert.Equal(0, queue.NumPending(), "Queue should have no pending jobs after WaitAndClose")
-		assert.Equal(0, internalQueue.Len(), "Internal queue should be empty after WaitAndClose")
-		assert.True(worker.IsStopped(), "Worker should be stopped after WaitAndClose")
 	})
 }

--- a/worker.go
+++ b/worker.go
@@ -62,25 +62,19 @@ type Worker interface {
 	// PauseAndWait pauses the worker and waits until all ongoing processes are done.
 	PauseAndWait() error
 	// Stop stops the worker and waits until all ongoing processes are done to gracefully close the channels.
-	// Time complexity: O(n) where n is the number of channels
 	Stop() error
 	// Restart restarts the worker and initializes new worker goroutines based on the concurrency.
-	// Time complexity: O(n) where n is the concurrency
 	Restart() error
 	// Resume continues processing jobs those are pending in the queue.
-	// Time complexity: O(n) where n is the concurrency
 	Resume() error
+	// WaitUntilFinished waits until all pending Jobs in the are processed.
+	WaitUntilFinished()
+	// WaitAndStop waits until all pending Jobs in the queue are processed and then closes the queue.
+	WaitAndStop() error
 
 	queue() IBaseQueue
 	configs() configs
 	notifyToPullNextJobs()
-
-	// WaitUntilFinished waits until all pending Jobs in the are processed.
-	WaitUntilFinished()
-
-	// WaitAndClose waits until all pending Jobs in the queue are processed and then closes the queue.
-	// Time complexity: O(n) where n is the number of pending Jobs
-	WaitAndStop() error
 }
 
 // newWorker creates a new worker with the given worker function and configurations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public queue and priority queue interfaces now provide a method to access the bound worker.
  - Workers now offer methods to wait for job completion and to wait and stop cleanly.

- **Refactor**
  - Queue interfaces and implementations have been simplified by removing worker lifecycle management methods from queues and delegating them to workers.
  - Internal abstractions were streamlined for clearer separation between queue and worker responsibilities.
  - Synchronization points in examples were updated to wait on workers instead of queues.

- **Bug Fixes**
  - Improved resource cleanup and synchronization behavior for workers and queues.

- **Tests**
  - Added and updated tests to verify worker job completion and stopping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->