### PR TITLE
refactor: use sync.Once for singleton nullQueue

### DIFF
--- a/examples/redis-persistent/main.go
+++ b/examples/redis-persistent/main.go
@@ -28,7 +28,7 @@ func main() {
 	defer func() {
 		fmt.Println("Time taken:", time.Since(start).Microseconds(), "ms")
 	}()
-	defer q.WaitUntilFinished()
+	defer w.WaitUntilFinished()
 	defer func() {
 		fmt.Println("Pending jobs:", q.NumPending())
 	}()

--- a/examples/sqlite-persistent/main.go
+++ b/examples/sqlite-persistent/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	// Bind the worker to the persistent queue
 	queue := worker.WithPersistentQueue(persistentQueue)
-	defer queue.WaitUntilFinished()
+	defer worker.WaitUntilFinished()
 
 	for i := range 10 {
 		queue.Add(fmt.Sprintf("Task %d", i))

--- a/null_queue.go
+++ b/null_queue.go
@@ -1,6 +1,7 @@
 package varmq
 
 import (
+	"sync"
 	"sync/atomic"
 )
 
@@ -11,19 +12,15 @@ type nullQueue struct {
 
 // Initialize a default nullQueue instance
 var defaultNullQueue IQueue
+var once sync.Once
 
 // getNullQueue returns a singleton instance of nullQueue
 func getNullQueue() IQueue {
-	if defaultNullQueue != nil {
-		return defaultNullQueue
-	}
+	once.Do(func() {
+		defaultNullQueue = &nullQueue{}
+	})
 
-	defaultNullQueue = &nullQueue{}
 	return defaultNullQueue
-}
-
-func (nq *nullQueue) NotificationChannel() <-chan struct{} {
-	return nil
 }
 
 func (nq *nullQueue) Dequeue() (any, bool) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization when waiting for job and task completion in example applications, ensuring more reliable shutdown behavior.
  - Prevented errors during worker shutdown by adding checks before signaling job processing.

- **Refactor**
  - Enhanced thread safety in internal queue initialization for better reliability.

- **Chores**
  - Removed an unused notification channel method from the internal queue implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->