### PR TITLE
fix: preserve paused status after in-flight jobs drain

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -199,7 +199,7 @@ func (w *worker[T, JobType]) releaseWaiters(processing uint32) {
 	if w.IsPaused() || (w.IsRunning() && w.queues.Len() == 0) {
 		// Broadcast to all waiters to signal they can continue
 		w.waiters.Broadcast()
-		w.status.Store(idle)
+		w.status.CompareAndSwap(running, idle)
 	}
 }
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -432,18 +432,17 @@ func TestWorkers(t *testing.T) {
 
 				// should process all jobs
 				assert.Equal(jobsProcessed.Load(), uint32(10), "All jobs should be processed after resume")
-
 				w.Stop()
 			})
 
 			t.Run("pause preserves status after in-flight jobs drain", func(t *testing.T) {
-				// This tests the edge case where releaseWaiters was overwriting
-				// paused status with idle after the last in-flight job completed.
-				var jobsProcessed atomic.Uint32
+				// Synchronization channels for deterministic testing
+				started := make(chan struct{}, 10) // signals when a job begins processing
+				resumeCh := make(chan struct{})    // blocks jobs until test releases them
 
 				fn := func(j iJob[int]) {
-					time.Sleep(50 * time.Millisecond) // Simulate slow work
-					jobsProcessed.Add(1)
+					started <- struct{}{} // signal that this job has started
+					<-resumeCh            // block until the test releases
 				}
 
 				w := newWorker(fn, WithConcurrency(2))
@@ -460,16 +459,19 @@ func TestWorkers(t *testing.T) {
 				err := w.start()
 				assert.NoError(err, "Worker should start without error")
 
-				// Wait briefly for jobs to start processing
-				time.Sleep(20 * time.Millisecond)
+				// Wait deterministically for at least one job to start processing
+				<-started
 				assert.True(w.IsActive(), "Worker should be active while processing jobs")
 
 				// Pause while jobs are still in-flight
 				err = w.Pause()
 				assert.NoError(err, "Pause should not error")
 
+				// Release all blocked jobs so in-flight work can drain
+				close(resumeCh)
+
 				// Wait for all in-flight jobs to finish
-				time.Sleep(200 * time.Millisecond)
+				w.WaitUntilIdle()
 
 				// Status should still be "Paused", not "Idle"
 				assert.True(w.IsPaused(), "Worker should remain paused after in-flight jobs drain")

--- a/worker_test.go
+++ b/worker_test.go
@@ -436,6 +436,49 @@ func TestWorkers(t *testing.T) {
 				w.Stop()
 			})
 
+			t.Run("pause preserves status after in-flight jobs drain", func(t *testing.T) {
+				// This tests the edge case where releaseWaiters was overwriting
+				// paused status with idle after the last in-flight job completed.
+				var jobsProcessed atomic.Uint32
+
+				fn := func(j iJob[int]) {
+					time.Sleep(50 * time.Millisecond) // Simulate slow work
+					jobsProcessed.Add(1)
+				}
+
+				w := newWorker(fn, WithConcurrency(2))
+				assert := assert.New(t)
+
+				q := queues.NewQueue[iJob[int]]()
+				w.queues.Register(q, math.MaxInt)
+
+				// Add enough jobs to keep the worker busy
+				for i := range 10 {
+					q.Enqueue(newJob(i, loadJobConfigs(w.configs())))
+				}
+
+				err := w.start()
+				assert.NoError(err, "Worker should start without error")
+
+				// Wait briefly for jobs to start processing
+				time.Sleep(20 * time.Millisecond)
+				assert.True(w.IsActive(), "Worker should be active while processing jobs")
+
+				// Pause while jobs are still in-flight
+				err = w.Pause()
+				assert.NoError(err, "Pause should not error")
+
+				// Wait for all in-flight jobs to finish
+				time.Sleep(200 * time.Millisecond)
+
+				// Status should still be "Paused", not "Idle"
+				assert.True(w.IsPaused(), "Worker should remain paused after in-flight jobs drain")
+				assert.Equal("Paused", w.Status(), "Status string should be 'Paused' after in-flight jobs drain")
+				assert.Zero(w.NumProcessing(), "No jobs should be processing")
+
+				w.Stop()
+			})
+
 			t.Run("restart functionality", func(t *testing.T) {
 				// Track job processing
 				var jobsProcessed atomic.Uint32


### PR DESCRIPTION
## Description
idle when the last in-flight job completed, even when the worker had been explicitly paused. This caused Pause() to appear ineffective when called while jobs were still processing.

Replace status.Store(idle) with status.CompareAndSwap(running, idle) so the transition only occurs from running state, preserving the paused status. Add test to verify worker remains in "Paused" state after in-flight jobs complete.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring


