### PR TITLE
refactor(worker): manage context inside event loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	go test -race -count=1 -timeout 5m -v ./...
 
 bench:
-	go test -bench=. -timeout 2m -benchmem
+	go test -bench=. -timeout 5m -benchmem
 
 # Format codes
 format:

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ init:
 
 # Run all tests (no cache)
 test:
-	go test -race -count=1 -v ./...
+	go test -race -count=1 -timeout 5m -v ./...
 
 bench:
-	go test -bench=. -benchmem
+	go test -bench=. -timeout 2m -benchmem
 
 # Format codes
 format:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init test format release
+.PHONY: help init test bench format release
 
 # Default target - list available targets
 help:

--- a/bench_test.go
+++ b/bench_test.go
@@ -28,7 +28,7 @@ func BenchmarkAdd(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		b.ResetTimer()
 		for j := range b.N {
@@ -42,7 +42,7 @@ func BenchmarkAdd(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		b.ResetTimer()
 		for i := range b.N {
@@ -57,7 +57,7 @@ func BenchmarkAdd(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		b.ResetTimer()
 		for j := range b.N {
@@ -72,7 +72,7 @@ func BenchmarkAdd(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		b.ResetTimer()
 		for i := range b.N {
@@ -87,7 +87,7 @@ func BenchmarkAdd(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		b.ResetTimer()
 		for j := range b.N {
@@ -102,7 +102,7 @@ func BenchmarkAdd(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		b.ResetTimer()
 		for i := range b.N {
@@ -120,7 +120,7 @@ func BenchmarkAddAll(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -138,7 +138,7 @@ func BenchmarkAddAll(b *testing.B) {
 		worker := NewWorker(task)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -156,7 +156,7 @@ func BenchmarkAddAll(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -174,7 +174,7 @@ func BenchmarkAddAll(b *testing.B) {
 		worker := NewErrWorker(errTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -192,7 +192,7 @@ func BenchmarkAddAll(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a standard queue
 		q := worker.BindQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {
@@ -210,7 +210,7 @@ func BenchmarkAddAll(b *testing.B) {
 		worker := NewResultWorker(resultTask)
 		// Bind the worker to a priority queue
 		q := worker.BindPriorityQueue()
-		defer worker.WaitAndStop()
+		defer worker.StopAndWait()
 
 		data := make([]Item[int], 1000) // Using a constant size of 1000 for testing
 		for i := range data {

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type ConfigFunc func(*configs)
 
 type configs struct {
 	concurrency              uint32
+	autoRun                  bool
 	strategy                 Strategy
 	minIdleWorkerRatio       uint8
 	jobIdGenerator           func() string
@@ -21,6 +22,7 @@ type configs struct {
 }
 
 var defaultConfig = configs{
+	autoRun:     true,
 	concurrency: 1,
 	jobIdGenerator: func() string {
 		return ""
@@ -204,6 +206,18 @@ func WithMinIdleWorkerRatio(percentage uint8) ConfigFunc {
 func WithConcurrency(concurrency int) ConfigFunc {
 	return func(c *configs) {
 		c.concurrency = withSafeConcurrency(concurrency)
+	}
+}
+
+// WithAutoRun configures whether the worker automatically starts when created.
+// When autoRun is true (the default), the worker begins processing immediately
+// after creation. When set to false, the worker remains in an initiated state
+// until Start() is called manually.
+//
+// Default: true
+func WithAutoRun(run bool) ConfigFunc {
+	return func(c *configs) {
+		c.autoRun = run
 	}
 }
 

--- a/examples/context-worker/main.go
+++ b/examples/context-worker/main.go
@@ -34,6 +34,6 @@ func main() {
 		q.Add(i)
 	}
 
-	w.WaitUntilIdle()
+	w.Wait()
 	fmt.Println("Worker stopped gracefully")
 }

--- a/job_test.go
+++ b/job_test.go
@@ -376,7 +376,7 @@ func TestJobCloseEdgeCases(t *testing.T) {
 		worker := newWorker(workerFunc)
 		queue := newPersistentQueue(worker, mockQueue)
 
-		worker.Resume()
+		worker.start()
 		queue.Add("test")
 		worker.Wait()
 	})

--- a/job_test.go
+++ b/job_test.go
@@ -375,8 +375,6 @@ func TestJobCloseEdgeCases(t *testing.T) {
 		mockQueue := mocks.NewMockPersistentQueue()
 		worker := newWorker(workerFunc)
 		queue := newPersistentQueue(worker, mockQueue)
-
-		worker.start()
 		queue.Add("test")
 		worker.Wait()
 	})

--- a/persistent_test.go
+++ b/persistent_test.go
@@ -16,20 +16,17 @@ func setupPersistentQueue() (PersistentQueue[string], *worker[string, iJob[strin
 	}
 
 	mockQueue := mocks.NewMockPersistentQueue()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newPersistentQueue(worker, mockQueue)
 
 	return queue, worker, mockQueue
 }
 
 func setupPersistentPriorityQueue() (PersistentPriorityQueue[string], *worker[string, iJob[string]], *mocks.MockPersistentPriorityQueue) {
-	// Create a worker with a simple process function
-	workerFunc := func(j iJob[string]) {
-		// Simple processor that doesn't return anything
-	}
+	workerFunc := func(j iJob[string]) {}
 
 	mockQueue := mocks.NewMockPersistentPriorityQueue()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newPersistentPriorityQueue(worker, mockQueue)
 
 	return queue, worker, mockQueue
@@ -304,7 +301,7 @@ func TestPersistentQueueCapacity(t *testing.T) {
 	t.Run("Add returns false when at capacity", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		ok1 := queue.Add("item-1")
@@ -322,7 +319,7 @@ func TestPersistentQueueCapacity(t *testing.T) {
 	t.Run("IsFull returns correct state", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		assert.False(t, queue.IsFull(), "Empty queue should not be full")
@@ -339,7 +336,7 @@ func TestPersistentPriorityQueueCapacity(t *testing.T) {
 	t.Run("Add returns false when at capacity", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentPriorityQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentPriorityQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		ok1 := queue.Add("high", 1)
@@ -357,7 +354,7 @@ func TestPersistentPriorityQueueCapacity(t *testing.T) {
 	t.Run("IsFull returns correct state", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentPriorityQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentPriorityQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		assert.False(t, queue.IsFull(), "Empty queue should not be full")

--- a/queue_manager.go
+++ b/queue_manager.go
@@ -1,14 +1,10 @@
 package varmq
 
 import (
-	"errors"
-
 	"github.com/goptics/varmq/internal/helpers"
 )
 
 type Strategy uint8
-
-var errInvalidStrategyType = errors.New("invalid strategy type")
 
 const (
 	// Selects queues in a round-robin fashion
@@ -37,8 +33,6 @@ func newQueueManager(strategy Strategy) *queueManager {
 
 func (qm *queueManager) next() (IBaseQueue, error) {
 	switch qm.strategy {
-	case Priority:
-		return qm.GetPriorityItem()
 	case RoundRobin:
 		return qm.GetRoundRobinItem()
 	case MaxLen:
@@ -46,6 +40,6 @@ func (qm *queueManager) next() (IBaseQueue, error) {
 	case MinLen:
 		return qm.GetMinLenItem()
 	default:
-		return nil, errInvalidStrategyType
+		return qm.GetPriorityItem()
 	}
 }

--- a/queue_manager_test.go
+++ b/queue_manager_test.go
@@ -30,16 +30,20 @@ func TestQueueManagerNext(t *testing.T) {
 		// Test round-robin behavior
 		queue1, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue1)
 
 		queue2, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue2)
 
 		queue3, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue3)
 
 		// Fourth call should cycle back to first queue
 		queue4, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue4)
 
 		// Order should be maintained in round-robin
 		assert.Equal(t, queue1, queue4, "Round-robin should cycle back to first queue")
@@ -70,6 +74,7 @@ func TestQueueManagerNext(t *testing.T) {
 		// MaxLen should always return the queue with the most items
 		queue, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue)
 		assert.Equal(t, 3, queue.Len(), "MaxLen strategy should return queue with the most items")
 		assert.Equal(t, q3, queue, "MaxLen strategy should return q3 with 3 items")
 	})
@@ -97,6 +102,7 @@ func TestQueueManagerNext(t *testing.T) {
 		// MinLen should always return the queue with the fewest items
 		queue, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue)
 		assert.Equal(t, 1, queue.Len(), "MinLen strategy should return queue with the fewest items")
 		assert.Equal(t, q1, queue, "MinLen strategy should return q1 with 1 item")
 	})
@@ -123,6 +129,7 @@ func TestQueueManagerNext(t *testing.T) {
 		// Priority should always return the queue with the highest priority first, provided it has items
 		queue, err := qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue)
 		assert.Equal(t, q3, queue, "Priority strategy should return q3 with highest priority 1")
 
 		// Remove q3 to test falling back to next highest priority
@@ -130,6 +137,7 @@ func TestQueueManagerNext(t *testing.T) {
 
 		queue, err = qm.next()
 		assert.NoError(t, err)
+		assert.NotNil(t, queue)
 		assert.Equal(t, q2, queue, "Priority strategy should return q2 with priority 5 after q3 is unregistered")
 	})
 
@@ -147,16 +155,17 @@ func TestQueueManagerNext(t *testing.T) {
 	})
 
 	t.Run("Invalid Strategy", func(t *testing.T) {
-		// Create queue manager with an invalid strategy (out of range)
+		// An out-of-range strategy falls back to the default (Priority).
 		invalidStrategy := Strategy(99)
 		qm := newQueueManager(invalidStrategy)
 
 		q := queues.NewQueue[any]()
 		qm.Register(q, math.MaxInt)
 
+		// Since no items are in the queue, next() returns ErrAllItemsEmpty via Priority fallback.
 		queue, err := qm.next()
-		assert.Error(t, err, "Should return error for invalid strategy")
-		assert.Nil(t, queue, "Should return nil queue for invalid strategy")
-		assert.Equal(t, "invalid strategy type", err.Error(), "Error message should indicate invalid strategy")
+		assert.Error(t, err, "Should return error when queue is empty")
+		assert.Nil(t, queue, "Should return nil queue when queue is empty")
+		assert.Equal(t, "all items are empty", err.Error(), "Error message should indicate empty queue")
 	})
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -18,7 +18,7 @@ func setupBasicQueue() (*queue[string], *worker[string, iJob[string]], *queues.Q
 	}
 
 	internalQueue := queues.NewQueue[any]()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -37,7 +37,7 @@ func setupResultQueue() (*resultQueue[string, int], *worker[string, iResultJob[s
 	}
 
 	internalQueue := queues.NewQueue[any]()
-	worker := newResultWorker(workerFunc)
+	worker := newResultWorker(workerFunc, WithAutoRun(false))
 	queue := newResultQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -53,7 +53,7 @@ func setupErrorQueue() (*errorQueue[string], *worker[string, iErrorJob[string]],
 	}
 
 	internalQueue := queues.NewQueue[any]()
-	worker := newErrWorker(workerFunc)
+	worker := newErrWorker(workerFunc, WithAutoRun(false))
 	queue := newErrorQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -62,13 +62,6 @@ func setupErrorQueue() (*errorQueue[string], *worker[string, iErrorJob[string]],
 // Test groups for each queue type
 func TestQueues(t *testing.T) {
 	t.Run("BasicQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupBasicQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue", func(t *testing.T) {
 			queue, _, internalQueue := setupBasicQueue()
 
@@ -83,7 +76,7 @@ func TestQueues(t *testing.T) {
 		t.Run("Processing job", func(t *testing.T) {
 			queue, worker, internalQueue := setupBasicQueue()
 
-			err := worker.start()
+			err := worker.Start()
 			assert.NoError(t, err, "Worker should start successfully")
 			defer worker.Stop()
 
@@ -110,7 +103,7 @@ func TestQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
+			err := worker.Start()
 			assert.NoError(t, err, "Worker should start successfully")
 			defer worker.Stop()
 
@@ -124,13 +117,6 @@ func TestQueues(t *testing.T) {
 	})
 
 	t.Run("ResultQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupResultQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue", func(t *testing.T) {
 			queue, _, internalQueue := setupResultQueue()
 
@@ -144,9 +130,7 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with result", func(t *testing.T) {
 			queue, worker, internalQueue := setupResultQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("42")
@@ -160,9 +144,7 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupResultQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("invalid")
@@ -189,8 +171,7 @@ func TestQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have five items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have five items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			results := groupJob.Results()
@@ -224,12 +205,6 @@ func TestQueues(t *testing.T) {
 	})
 
 	t.Run("ErrorQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupErrorQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
 
 		t.Run("Adding job to queue", func(t *testing.T) {
 			queue, _, internalQueue := setupErrorQueue()
@@ -244,13 +219,11 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with success", func(t *testing.T) {
 			queue, worker, internalQueue := setupErrorQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("success")
-			err = job.Err()
+			err := job.Err()
 
 			assert.NoError(t, err, "Job should complete without error")
 			assert.Equal(t, 0, queue.Len(), "Queue should have no pending jobs")
@@ -259,13 +232,11 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupErrorQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("error")
-			err = job.Err()
+			err := job.Err()
 
 			assert.Error(t, err, "Job should return an error")
 			assert.Equal(t, "test error", err.Error(), "Error message should match expected")
@@ -286,8 +257,7 @@ func TestQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			errors := groupJob.Errs()
@@ -318,7 +288,7 @@ func setupPriorityQueue() (*priorityQueue[string], *worker[string, iJob[string]]
 	}
 
 	internalQueue := queues.NewPriorityQueue[any]()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newPriorityQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -337,7 +307,7 @@ func setupResultPriorityQueue() (*resultPriorityQueue[string, int], *worker[stri
 	}
 
 	internalQueue := queues.NewPriorityQueue[any]()
-	worker := newResultWorker(workerFunc)
+	worker := newResultWorker(workerFunc, WithAutoRun(false))
 	queue := newResultPriorityQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -353,7 +323,7 @@ func setupErrorPriorityQueue() (*errorPriorityQueue[string], *worker[string, iEr
 	}
 
 	internalQueue := queues.NewPriorityQueue[any]()
-	worker := newErrWorker(workerFunc)
+	worker := newErrWorker(workerFunc, WithAutoRun(false))
 	queue := newErrorPriorityQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -362,13 +332,6 @@ func setupErrorPriorityQueue() (*errorPriorityQueue[string], *worker[string, iEr
 func TestPriorityQueues(t *testing.T) {
 	// Test cases for Priority Queue
 	t.Run("PriorityQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupPriorityQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue with priority", func(t *testing.T) {
 			queue, _, internalQueue := setupPriorityQueue()
 
@@ -389,8 +352,7 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing jobs with priority order", func(t *testing.T) {
 			queue, worker, _ := setupPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			// Add jobs with different priorities (lower number = higher priority)
@@ -421,8 +383,7 @@ func TestPriorityQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			// Wait for all jobs to complete
@@ -435,12 +396,6 @@ func TestPriorityQueues(t *testing.T) {
 	})
 
 	t.Run("ResultPriorityQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupResultPriorityQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
 
 		t.Run("Adding job to queue with priority", func(t *testing.T) {
 			queue, _, internalQueue := setupResultPriorityQueue()
@@ -463,8 +418,7 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing job with result and priority", func(t *testing.T) {
 			queue, worker, _ := setupResultPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			// Add jobs with different priorities (lower number = higher priority)
@@ -489,8 +443,7 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupResultPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("invalid", 1)
@@ -515,8 +468,7 @@ func TestPriorityQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			results := groupJob.Results()
@@ -538,13 +490,6 @@ func TestPriorityQueues(t *testing.T) {
 	})
 
 	t.Run("ErrorPriorityQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupErrorPriorityQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue with priority", func(t *testing.T) {
 			queue, _, internalQueue := setupErrorPriorityQueue()
 
@@ -566,12 +511,11 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing successful job", func(t *testing.T) {
 			queue, worker, _ := setupErrorPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("success", 1)
-			err = job.Err()
+			err := job.Err()
 
 			assert.NoError(t, err, "Job should complete without error")
 		})
@@ -579,12 +523,11 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupErrorPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("error", 1)
-			err = job.Err()
+			err := job.Err()
 
 			assert.Error(t, err, "Job should return an error")
 			assert.Equal(t, "test error", err.Error(), "Error message should match expected")
@@ -605,8 +548,7 @@ func TestPriorityQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			errors := groupJob.Errs()
@@ -677,9 +619,7 @@ func TestExternalQueue(t *testing.T) {
 		queue, worker, _ := setupBasicQueue()
 		assert := assert.New(t)
 
-		// Start the worker
-		err := worker.start()
-		assert.NoError(err, "Worker should start successfully")
+		worker.Start()
 
 		// Add several jobs
 		for i := range 5 {
@@ -688,7 +628,7 @@ func TestExternalQueue(t *testing.T) {
 		assert.LessOrEqual(queue.Len(), 5, "Queue should have at most five pending jobs")
 
 		// Close the queue
-		err = queue.Close()
+		err := queue.Close()
 		assert.NoError(err, "Close should not return an error")
 
 		_, ok := queue.Add("test-data-6")
@@ -704,7 +644,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("item-1")
@@ -739,7 +679,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Zero capacity means unlimited", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(0))
 
 			for i := range 100 {
@@ -762,7 +702,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("IsFull returns correct state", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			assert.False(t, queue.IsFull(), "Empty queue should not be full")
@@ -788,7 +728,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("high", 1)
@@ -806,7 +746,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -824,7 +764,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("item-1")
@@ -842,7 +782,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -861,7 +801,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("item-1")
@@ -879,7 +819,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -898,7 +838,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("high", 1)
@@ -916,7 +856,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -934,7 +874,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("high", 1)
@@ -952,7 +892,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{

--- a/queue_test.go
+++ b/queue_test.go
@@ -620,6 +620,7 @@ func TestExternalQueue(t *testing.T) {
 		assert := assert.New(t)
 
 		worker.Start()
+		defer worker.Stop()
 
 		// Add several jobs
 		for i := range 5 {
@@ -662,7 +663,8 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
+
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{

--- a/waiters_test.go
+++ b/waiters_test.go
@@ -812,6 +812,7 @@ func TestWaiters(t *testing.T) {
 			// Wait for job to complete and stop
 			select {
 			case <-done:
+				w.WaitUntilStopped()
 				assert.True(w.IsStopped(), "Worker should be Stopped")
 				assert.Equal(0, w.NumPending(), "Queue should be empty")
 			case <-time.After(2 * time.Second):
@@ -826,6 +827,7 @@ func TestWaiters(t *testing.T) {
 			assert := assert.New(t)
 			err := w.WaitAndStop()
 			assert.NoError(err)
+			w.WaitUntilStopped()
 			assert.True(w.IsStopped(), "Worker should be stopped")
 		})
 	})

--- a/waiters_test.go
+++ b/waiters_test.go
@@ -1,6 +1,7 @@
 package varmq
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,8 +17,6 @@ func TestWaiters(t *testing.T) {
 	t.Run("Wait", func(t *testing.T) {
 		t.Run("returns immediately when idle with no work", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			err := w.start()
-			assert.NoError(t, err)
 			defer w.Stop()
 
 			done := make(chan struct{})
@@ -54,7 +53,9 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("waits for queue to drain", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{}, 2)
 			w := newWorker(func(j iJob[string]) {
+				started <- struct{}{}
 				<-blockCh
 			})
 			assert := assert.New(t)
@@ -62,23 +63,19 @@ func TestWaiters(t *testing.T) {
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
 
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
-			// Add jobs to queue
 			for i := range 2 {
 				q.Enqueue(newJob("job-"+string(rune(i)), loadJobConfigs(w.configs())))
 			}
 			w.notifyToPullNextJobs()
 
-			// Wait for at least one job to be in-flight
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Greater(w.NumProcessing(), 0, "At least one job should be in-flight")
 
 			done := make(chan struct{})
@@ -120,8 +117,6 @@ func TestWaiters(t *testing.T) {
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
 
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
 			// Enqueue a job that will block
@@ -131,18 +126,10 @@ func TestWaiters(t *testing.T) {
 			// Wait for job to start
 			select {
 			case <-started:
-				// Job has started
 			case <-time.After(500 * time.Millisecond):
 				t.Fatal("Job should have started")
 			}
 
-			// Poll until NumProcessing > 0 (for -race resilience)
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
-			}
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -174,12 +161,8 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns when paused with no in-flight jobs", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Pause with no work
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -202,20 +185,16 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns when stopped with no in-flight jobs", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
+			err := w.Stop()
 			assert.NoError(err)
+			w.WaitUntilStopped()
+			assert.True(w.IsStopped(), "Worker should be stopped")
 
-		err = w.Stop()
-		assert.NoError(err)
-		w.WaitUntilStopped()
-		assert.True(w.IsStopped(), "Worker should be stopped")
-
-		done := make(chan struct{})
-		go func() {
-			w.Wait()
-			close(done)
-		}()
+			done := make(chan struct{})
+			go func() {
+				w.Wait()
+				close(done)
+			}()
 
 			select {
 			case <-done:
@@ -236,10 +215,6 @@ func TestWaiters(t *testing.T) {
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Start a job that blocks
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
@@ -247,24 +222,16 @@ func TestWaiters(t *testing.T) {
 			// Wait for job to start
 			select {
 			case <-started:
-				// Job started
 			case <-time.After(500 * time.Millisecond):
 				t.Fatal("Job should have started")
 			}
 
-			// Poll until NumProcessing > 0 (for -race resilience)
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
-			}
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			// Pause while job is in-flight -> transitions to Pausing
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
-			assert.Equal(pausing, w.status.Load(), "Status should be Pausing")
+			assert.Equal(pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 			done := make(chan struct{})
 			go func() {
@@ -298,8 +265,6 @@ func TestWaiters(t *testing.T) {
 	t.Run("WaitUntilIdle", func(t *testing.T) {
 		t.Run("returns immediately when already idle", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			err := w.start()
-			assert.NoError(t, err)
 			defer w.Stop()
 
 			done := make(chan struct{})
@@ -328,8 +293,6 @@ func TestWaiters(t *testing.T) {
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
 
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
 			// Add a job that will cause Running status
@@ -374,11 +337,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("blocks when paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -388,13 +347,14 @@ func TestWaiters(t *testing.T) {
 				close(done)
 			}()
 
-			// Should block because Paused != Idle
 			select {
 			case <-done:
 				t.Fatal("WaitUntilIdle() should block when worker is Paused")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Resume()
+			<-done
 
 			w.Stop()
 		})
@@ -402,28 +362,27 @@ func TestWaiters(t *testing.T) {
 		t.Run("blocks when stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
+			err := w.Stop()
 			assert.NoError(err)
+			w.WaitUntilStopped()
+			assert.True(w.IsStopped(), "Worker should be stopped")
 
-		err = w.Stop()
-		assert.NoError(err)
-		w.WaitUntilStopped()
-		assert.True(w.IsStopped(), "Worker should be stopped")
+			done := make(chan struct{})
+			go func() {
+				w.WaitUntilIdle()
+				close(done)
+			}()
 
-		done := make(chan struct{})
-		go func() {
-			w.WaitUntilIdle()
-			close(done)
-		}()
-
-			// Should block because Stopped != Idle
 			select {
 			case <-done:
 				t.Fatal("WaitUntilIdle() should block when worker is Stopped")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Restart()
+			<-done
+
+			w.Stop()
 		})
 	})
 
@@ -431,11 +390,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns immediately when already paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -457,34 +412,30 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("waits for pausing to paused transition", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 			})
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
 
-			// Wait for job to start (polling loop for -race resilience)
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			// Pause -> transitions to Pausing
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
-			assert.Equal(pausing, w.status.Load(), "Status should be Pausing")
+			assert.Equal(pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 			done := make(chan struct{})
 			go func() {
@@ -515,11 +466,6 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("blocks when never paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-			defer w.Stop()
 
 			done := make(chan struct{})
 			go func() {
@@ -527,13 +473,16 @@ func TestWaiters(t *testing.T) {
 				close(done)
 			}()
 
-			// Worker is Idle, never paused - should block indefinitely
 			select {
 			case <-done:
 				t.Fatal("WaitUntilPaused() should block when worker is never paused")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Pause()
+			<-done
+
+			w.Stop()
 		})
 	})
 
@@ -541,20 +490,16 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns immediately when already stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
+			err := w.Stop()
 			assert.NoError(err)
-
-		err = w.Stop()
-		assert.NoError(err)
-		w.WaitUntilStopped()
-		assert.True(w.IsStopped(), "Worker should be stopped")
-
-		done := make(chan struct{})
-		go func() {
 			w.WaitUntilStopped()
-			close(done)
-		}()
+			assert.True(w.IsStopped(), "Worker should be stopped")
+
+			done := make(chan struct{})
+			go func() {
+				w.WaitUntilStopped()
+				close(done)
+			}()
 
 			select {
 			case <-done:
@@ -566,25 +511,28 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("waits for stopping to stopped transition", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 			})
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
-			time.Sleep(20 * time.Millisecond)
+
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
+			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			// Stop -> transitions to Stopping
-			err = w.Stop()
+			err := w.Stop()
 			assert.NoError(err)
 			assert.Equal(stopping, w.status.Load(), "Status should be Stopping")
 
@@ -615,10 +563,6 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("blocks when never stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
 			done := make(chan struct{})
@@ -651,21 +595,16 @@ func TestWaiters(t *testing.T) {
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
 
-			// Wait for job to start
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -701,11 +640,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("with no jobs returns immediately paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.PauseAndWait()
+			err := w.PauseAndWait()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused immediately")
 
@@ -713,8 +648,7 @@ func TestWaiters(t *testing.T) {
 		})
 
 		t.Run("returns error when not running", func(t *testing.T) {
-			w := newWorker(func(j iJob[string]) {})
-			// Never started
+			w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 
 			err := w.PauseAndWait()
 			assert.ErrorIs(t, err, ErrNotRunningWorker)
@@ -724,19 +658,17 @@ func TestWaiters(t *testing.T) {
 	t.Run("WaitAndPause", func(t *testing.T) {
 		t.Run("waits for work then pauses", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {
-				time.Sleep(30 * time.Millisecond)
-			})
+				time.Sleep(500 * time.Millisecond)
+			}, WithAutoRun(false))
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Add a job
 			q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
+
+			w.Start()
+			defer w.Stop()
 
 			done := make(chan struct{})
 			go func() {
@@ -745,34 +677,26 @@ func TestWaiters(t *testing.T) {
 				close(done)
 			}()
 
-			// Should block while job is processing
 			select {
 			case <-done:
 				t.Fatal("WaitAndPause() should block while work is in progress")
-			case <-time.After(20 * time.Millisecond):
-				// Expected
+			case <-time.After(200 * time.Millisecond):
 			}
 
-			// Wait for job to complete and pause
 			select {
 			case <-done:
 				assert.True(w.IsPaused(), "Worker should be Paused")
 				assert.Equal(0, w.NumPending(), "Queue should be empty")
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(2 * time.Second):
 				t.Fatal("WaitAndPause() should return after work completes")
 			}
 
-			w.Stop()
 		})
 
 		t.Run("returns immediately when no work", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.WaitAndPause()
+			err := w.WaitAndPause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -783,23 +707,26 @@ func TestWaiters(t *testing.T) {
 	t.Run("StopAndWait", func(t *testing.T) {
 		t.Run("with in-flight jobs blocks until stopped", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			var processed bool
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 				processed = true
-			})
+			}, WithAutoRun(false))
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
-			w.notifyToPullNextJobs()
-			time.Sleep(20 * time.Millisecond)
+			w.Start()
+
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
+			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -835,11 +762,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("with no jobs returns immediately stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.StopAndWait()
+			err := w.StopAndWait()
 			assert.NoError(err)
 			assert.True(w.IsStopped(), "Worker should be stopped immediately")
 		})
@@ -848,28 +771,24 @@ func TestWaiters(t *testing.T) {
 	t.Run("WaitAndStop", func(t *testing.T) {
 		t.Run("waits for work then stops", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 			})
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Add a blocking job
 			q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
 
-			// Wait for job to start
-			for i := 0; i < 100; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -905,11 +824,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns immediately when no work", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.WaitAndStop()
+			err := w.WaitAndStop()
 			assert.NoError(err)
 			assert.True(w.IsStopped(), "Worker should be stopped")
 		})
@@ -919,16 +834,10 @@ func TestWaiters(t *testing.T) {
 		t.Run("Wait returns when paused, WaitUntilIdle blocks", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Pause with no work -> status is Paused immediately
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
-			// Wait() should return because no work and no processing
 			doneWait := make(chan struct{})
 			go func() {
 				w.Wait()
@@ -937,12 +846,10 @@ func TestWaiters(t *testing.T) {
 
 			select {
 			case <-doneWait:
-				// Success - Wait returns when paused with no work
 			case <-time.After(100 * time.Millisecond):
 				t.Fatal("Wait() should return when paused with no work")
 			}
 
-			// WaitUntilIdle() should block because status is Paused, not Idle
 			doneIdle := make(chan struct{})
 			go func() {
 				w.WaitUntilIdle()
@@ -953,8 +860,10 @@ func TestWaiters(t *testing.T) {
 			case <-doneIdle:
 				t.Fatal("WaitUntilIdle() should block when status is Paused")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Resume()
+			<-doneIdle
 
 			w.Stop()
 		})
@@ -975,10 +884,6 @@ func TestWaiters(t *testing.T) {
 
 			q := queues.NewQueue[iJob[int]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Start some jobs
 			for i := range 3 {
 				q.Enqueue(newJob(i, loadJobConfigs(w.configs())))
@@ -1016,7 +921,7 @@ func TestWaiters(t *testing.T) {
 			select {
 			case <-done:
 				assert.True(w.IsActive(), "Worker should be active after restart")
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(2 * time.Second):
 				t.Fatal("Restart() should return after in-flight jobs complete")
 			}
 

--- a/waiters_test.go
+++ b/waiters_test.go
@@ -206,15 +206,16 @@ func TestWaiters(t *testing.T) {
 			err := w.start()
 			assert.NoError(err)
 
-			err = w.Stop()
-			assert.NoError(err)
-			assert.True(w.IsStopped(), "Worker should be stopped")
+		err = w.Stop()
+		assert.NoError(err)
+		w.WaitUntilStopped()
+		assert.True(w.IsStopped(), "Worker should be stopped")
 
-			done := make(chan struct{})
-			go func() {
-				w.Wait()
-				close(done)
-			}()
+		done := make(chan struct{})
+		go func() {
+			w.Wait()
+			close(done)
+		}()
 
 			select {
 			case <-done:
@@ -405,15 +406,16 @@ func TestWaiters(t *testing.T) {
 			err := w.start()
 			assert.NoError(err)
 
-			err = w.Stop()
-			assert.NoError(err)
-			assert.True(w.IsStopped(), "Worker should be stopped")
+		err = w.Stop()
+		assert.NoError(err)
+		w.WaitUntilStopped()
+		assert.True(w.IsStopped(), "Worker should be stopped")
 
-			done := make(chan struct{})
-			go func() {
-				w.WaitUntilIdle()
-				close(done)
-			}()
+		done := make(chan struct{})
+		go func() {
+			w.WaitUntilIdle()
+			close(done)
+		}()
 
 			// Should block because Stopped != Idle
 			select {
@@ -543,15 +545,16 @@ func TestWaiters(t *testing.T) {
 			err := w.start()
 			assert.NoError(err)
 
-			err = w.Stop()
-			assert.NoError(err)
-			assert.True(w.IsStopped(), "Worker should be stopped")
+		err = w.Stop()
+		assert.NoError(err)
+		w.WaitUntilStopped()
+		assert.True(w.IsStopped(), "Worker should be stopped")
 
-			done := make(chan struct{})
-			go func() {
-				w.WaitUntilStopped()
-				close(done)
-			}()
+		done := make(chan struct{})
+		go func() {
+			w.WaitUntilStopped()
+			close(done)
+		}()
 
 			select {
 			case <-done:

--- a/waiters_test.go
+++ b/waiters_test.go
@@ -34,8 +34,7 @@ func TestWaiters(t *testing.T) {
 		})
 
 		t.Run("returns immediately when initiated", func(t *testing.T) {
-			w := newWorker(func(j iJob[string]) {})
-			// Worker is in initiated state, never started
+			w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 
 			done := make(chan struct{})
 			go func() {
@@ -45,7 +44,6 @@ func TestWaiters(t *testing.T) {
 
 			select {
 			case <-done:
-				// Success
 			case <-time.After(100 * time.Millisecond):
 				t.Fatal("Wait() should return immediately for initiated worker")
 			}

--- a/waiters_test.go
+++ b/waiters_test.go
@@ -2,8 +2,6 @@ package varmq
 
 import (
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -869,63 +867,33 @@ func TestWaiters(t *testing.T) {
 		})
 	})
 
-	t.Run("Restart uses Wait correctly", func(t *testing.T) {
-		t.Run("restart with running jobs waits then restarts", func(t *testing.T) {
-			started := make(chan struct{})
-			var startOnce sync.Once
-			blockCh := make(chan struct{})
-			var processed atomic.Int32
-			w := newWorker(func(j iJob[int]) {
-				processed.Add(1)
-				startOnce.Do(func() { close(started) })
-				<-blockCh
-			})
-			assert := assert.New(t)
+	t.Run("Restart blocks until in-flight jobs drain", func(t *testing.T) {
+		blockCh := make(chan struct{})
+		w := newWorker(func(j iJob[int]) {
+			<-blockCh
+		}, WithAutoRun(false))
+		q := queues.NewQueue[iJob[int]]()
+		w.queues.Register(q, 1)
+		q.Enqueue(newJob(1, loadJobConfigs(w.configs())))
+		w.Start()
 
-			q := queues.NewQueue[iJob[int]]()
-			w.queues.Register(q, 1)
-			// Start some jobs
-			for i := range 3 {
-				q.Enqueue(newJob(i, loadJobConfigs(w.configs())))
-			}
-			w.notifyToPullNextJobs()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
 
-			// Wait for at least one job to start
-			select {
-			case <-started:
-				// Job started
-			case <-time.After(500 * time.Millisecond):
-				t.Fatal("Some jobs should have started")
-			}
-			assert.Greater(processed.Load(), int32(0), "Some jobs should have started")
+		done := make(chan struct{})
+		go func() {
+			assert.NoError(t, w.Restart())
+			close(done)
+		}()
 
-			// Restart should wait for in-flight jobs, then restart
-			done := make(chan struct{})
-			go func() {
-				err := w.Restart()
-				assert.NoError(err)
-				close(done)
-			}()
+		close(blockCh)
 
-			// Should block while jobs are in-flight
-			select {
-			case <-done:
-				t.Fatal("Restart() should block while jobs are in-flight")
-			case <-time.After(50 * time.Millisecond):
-				// Expected
-			}
+		select {
+		case <-done:
+			assert.True(t, w.IsActive(), "Worker should be active after restart")
+		case <-time.After(2 * time.Second):
+			t.Fatal("Restart() should return after in-flight jobs complete")
+		}
 
-			// Release all jobs
-			close(blockCh)
-
-			select {
-			case <-done:
-				assert.True(w.IsActive(), "Worker should be active after restart")
-			case <-time.After(2 * time.Second):
-				t.Fatal("Restart() should return after in-flight jobs complete")
-			}
-
-			w.Stop()
-		})
+		w.Stop()
 	})
 }

--- a/worker.go
+++ b/worker.go
@@ -3,7 +3,6 @@ package varmq
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -477,7 +476,7 @@ func (w *worker[T, JobType]) processNextJob() error {
 	queue, err := w.queues.next()
 
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrGetNextQueue, err)
+		return ErrGetNextQueue
 	}
 
 	w.curProcessing.Add(1)
@@ -667,7 +666,12 @@ func (w *worker[T, JobType]) goEventLoop() {
 			case <-signal:
 				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
 					if err := w.processNextJob(); err != nil {
-						w.sendError(err)
+						switch {
+						case errors.Is(err, ErrGetNextQueue):
+							break
+						default:
+							w.sendError(err)
+						}
 					}
 				}
 			}

--- a/worker.go
+++ b/worker.go
@@ -709,18 +709,22 @@ func (w *worker[T, JobType]) Resume() error {
 }
 
 func (w *worker[T, JobType]) start() error {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
 	if w.IsActive() {
 		return ErrRunningWorker
 	}
-
-	defer w.notifyToPullNextJobs()
-	defer w.status.Store(idle)
 
 	w.goEventLoop()
 	w.goRemoveIdleWorkers()
 
 	// init the first worker by default
 	w.pool.PushNode(w.initPoolNode())
+
+	w.status.Store(idle)
+	w.waiters.Broadcast()
+	w.notifyToPullNextJobs()
 
 	return nil
 }
@@ -747,9 +751,23 @@ func (w *worker[T, JobType]) Restart() error {
 		return err
 	}
 
-	w.WaitUntilStopped()
+	// Wait for the worker to reach a terminal state (stopped or active).
+	// If another goroutine already restarted this worker while we were
+	// waiting, IsActive() will be true and we return ErrRunningWorker.
+	// sync.Cond.Wait() atomically releases w.mx and re-acquires it on wake-up.
+	w.mx.Lock()
+	for !w.IsStopped() && !w.IsActive() {
+		w.waiters.Wait()
+	}
+	if w.IsActive() {
+		w.mx.Unlock()
+		return ErrRunningWorker
+	}
 
+	// Create a new context before releasing the lock so that start()
+	// and the event loop goroutine see the updated context.
 	w.ctx, w.cancel = context.WithCancel(w.Configs.ctx)
+	w.mx.Unlock()
 
 	return w.start()
 }

--- a/worker.go
+++ b/worker.go
@@ -201,12 +201,6 @@ type Worker interface {
 	//   - ErrWorkerStopping: worker is in the Stopping state.
 	//   - ErrWorkerPausing: worker is in the Pausing state.
 	Start() error
-	// WaitUntilFinished waits until all pending jobs are processed and the worker
-	// has no in-flight work. This is an alias for Wait().
-	//
-	// Deprecated: Use Wait() or WaitUntilIdle() instead, depending on whether you
-	// care about the final status or just that work is done.
-	WaitUntilFinished()
 	// Wait blocks until the worker has no pending jobs in the queue and no jobs
 	// currently being processed.
 	//
@@ -255,10 +249,12 @@ type Worker interface {
 	// Note: If the worker is already Stopped, this returns immediately.
 	WaitUntilStopped()
 	// WaitAndStop waits until all pending jobs are processed and in-flight
-	// jobs complete, then stops the worker and blocks until fully stopped.
+	// jobs complete, then initiates a graceful stop and returns immediately.
 	//
-	// This is equivalent to calling Wait(), Stop(), and WaitUntilStopped().
+	// This is equivalent to calling Wait() followed by Stop().
 	// Use this when you want to drain the queue before shutting down.
+	// Use StopAndWait() when you need to block until the worker reaches
+	// the Stopped state.
 	//
 	// Errors:
 	//   - see Stop() for error documentation.
@@ -412,13 +408,6 @@ func (w *worker[T, JobType]) sendError(err error) {
 
 func (w *worker[T, JobType]) Metrics() Metrics {
 	return w.metrics
-}
-
-// WaitUntilFinished waits until all pending jobs are processed.
-//
-// Deprecated: Use Wait() or WaitUntilIdle() instead.
-func (w *worker[T, JobType]) WaitUntilFinished() {
-	w.Wait()
 }
 
 // Wait blocks until the worker has no pending jobs in the queue
@@ -960,11 +949,5 @@ func (w *worker[T, JobType]) StopAndWait() error {
 
 func (w *worker[T, JobType]) WaitAndStop() error {
 	w.Wait()
-
-	if err := w.Stop(); err != nil {
-		return err
-	}
-
-	w.WaitUntilStopped()
-	return nil
+	return w.Stop()
 }

--- a/worker.go
+++ b/worker.go
@@ -696,22 +696,13 @@ func (w *worker[T, JobType]) Pause() error {
 }
 
 func (w *worker[T, JobType]) Resume() error {
-	if w.IsStopped() {
-		return ErrWorkerStopped
+	if w.IsPaused() {
+		w.status.Store(idle)
+		w.notifyToPullNextJobs()
+		return nil
 	}
 
-	if w.IsActive() {
-		return ErrRunningWorker
-	}
-
-	if !w.IsPaused() {
-		return ErrNotRunningWorker
-	}
-
-	w.status.Store(idle)
-	w.notifyToPullNextJobs()
-
-	return nil
+	return w.getStatusError()
 }
 
 func (w *worker[T, JobType]) start() error {

--- a/worker.go
+++ b/worker.go
@@ -88,14 +88,13 @@ type Worker interface {
 	IsPaused() bool
 	// IsStopped returns whether the worker is in the Stopped state.
 	//
-	// A stopped worker has ceased all processing, closed its channels,
-	// and removed all worker goroutines. It cannot be resumed; use Restart()
-	// to create a fresh worker instance.
+	// A stopped worker has ceased all processing and removed all worker
+	// goroutines. It cannot be resumed; use Restart() to start again.
 	IsStopped() bool
 	// Status returns the human-readable current status of the worker.
 	//
 	// Possible values: "Idle", "Running", "Pausing", "Paused",
-	// "Stopping", "Stopped", "Restarting"
+	// "Stopping", "Stopped"
 	Status() string
 	// NumProcessing returns the number of jobs currently being processed
 	// by the worker (in-flight jobs).
@@ -136,21 +135,17 @@ type Worker interface {
 
 	// Stop initiates a graceful shutdown of the worker.
 	//
-	// This is non-blocking and returns immediately. The behavior depends on
-	// whether there are in-flight jobs:
-	//   - If no jobs are processing: stops immediately — channels are closed, worker goroutines
-	// 		 are removed, and status becomes Stopped.
-	//   - If jobs are processing: transitions to Stopping. In-flight jobs
-	//     continue until completion, then the full cleanup runs and status
-	//     becomes Stopped.
+	// This is non-blocking and returns immediately. The worker transitions
+	// to Stopping and cancels its internal context. The event loop then
+	// waits for in-flight jobs to finish, removes all worker goroutines,
+	// and transitions to Stopped.
 	//
 	// A stopped worker cannot be resumed; use Restart() instead.
 	// Use StopAndWait() to block until fully stopped.
 	Stop() error
 	// Restart gracefully restarts the worker, preserving any pending
-	// jobs in the queue. Ongoing jobs are allowed to complete before
-	// the worker is stopped and reinitialized with fresh worker goroutines
-	// based on the current concurrency setting.
+	// jobs in the queue. It stops the worker, waits for it to reach
+	// Stopped, recreates the internal context, and starts again.
 	Restart() error
 	// Resume resumes a paused worker and begins processing pending
 	// jobs from the queue. This has no effect on a stopped worker —
@@ -168,7 +163,7 @@ type Worker interface {
 	// This returns when:
 	//   - Status is Running or Idle: queue is empty AND curProcessing == 0
 	//   - Status is Paused or Stopped: curProcessing == 0 (all in-flight jobs done)
-	//   - Status is Pausing, Stopping, or Restarting: waits until transition completes
+	//   - Status is Pausing or Stopping: curProcessing == 0
 	//
 	// Unlike WaitUntilIdle(), this does NOT require the status to be Idle.
 	// For example, if Pause() is called and all jobs drain, Wait() returns
@@ -188,9 +183,8 @@ type Worker interface {
 	//   - If status is Paused with no work, it blocks indefinitely (Paused != Idle)
 	//   - If status is Stopped, it blocks indefinitely (Stopped != Idle)
 	//
-	// Use this when you need the worker in the Idle state specifically, such as
-	// during Restart() when cleanup must only happen after the worker transitions
-	// from Running -> Idle. Use Wait() when you only care that work is done.
+	// Use this when you need the worker in the Idle state specifically.
+	// Use Wait() when you only care that work is done.
 	//
 	// Note: If the worker is already Idle with no pending jobs, this returns immediately.
 	WaitUntilIdle()
@@ -211,17 +205,17 @@ type Worker interface {
 	// Note: If the worker is already Stopped, this returns immediately.
 	WaitUntilStopped()
 	// WaitAndStop waits until all pending jobs are processed and in-flight
-	// jobs complete, then stops the worker.
+	// jobs complete, then stops the worker and blocks until fully stopped.
 	//
-	// This is equivalent to calling Wait() followed by Stop(). Use this
-	// when you want to drain the queue before shutting down.
+	// This is equivalent to calling Wait(), Stop(), and WaitUntilStopped().
+	// Use this when you want to drain the queue before shutting down.
 	WaitAndStop() error
 	// StopAndWait initiates a graceful stop and blocks until the worker
 	// reaches the Stopped state.
 	//
 	// This is equivalent to calling Stop() followed by WaitUntilStopped().
 	// If there are in-flight jobs, this blocks until they complete and
-	// the full cleanup (closing channels, removing goroutines) finishes.
+	// all worker goroutines are removed.
 	StopAndWait() error
 	// WaitAndPause waits until all pending jobs are processed and in-flight
 	// jobs complete, then pauses the worker.

--- a/worker.go
+++ b/worker.go
@@ -22,7 +22,6 @@ const (
 	paused
 	stopping
 	stopped
-	restarting
 )
 
 const (
@@ -38,7 +37,6 @@ var (
 	ErrWorkerStopped    = errors.New("worker is stopped")
 	ErrWorkerPausing    = errors.New("worker is pausing")
 	ErrWorkerStopping   = errors.New("worker is stopping")
-	ErrWorkerRestarting = errors.New("worker is restarting")
 	ErrSameConcurrency  = errors.New("worker already has the same concurrency")
 	ErrFailedToDequeue  = errors.New("failed to dequeue job")
 	ErrFailedToCastJob  = errors.New("failed to cast job")
@@ -57,7 +55,6 @@ type worker[T any, JobType iJob[T]] struct {
 	eventLoopSignal chan struct{}
 	errorChan       chan error
 	waiters         *sync.Cond
-	tickers         []*time.Ticker
 	mx              sync.RWMutex
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -256,16 +253,12 @@ func newWorker[T any](wf func(j iJob[T]), configs ...any) *worker[T, iJob[T]] {
 		metrics:         newMetrics(),
 		eventLoopSignal: make(chan struct{}, eventLoopSignalCap),
 		errorChan:       make(chan error, errorChanCap),
-		tickers:         make([]*time.Ticker, 0),
 		Configs:         c,
 	}
 
 	w.waiters = sync.NewCond(&w.mx)
 	w.concurrency.Store(c.concurrency)
-
-	if c.ctx != nil {
-		w.ctx, w.cancel = context.WithCancel(c.ctx)
-	}
+	w.initContext(c.ctx)
 
 	return w
 }
@@ -281,16 +274,12 @@ func newErrWorker[T any](wf func(j iErrorJob[T]), configs ...any) *worker[T, iEr
 		metrics:         newMetrics(),
 		eventLoopSignal: make(chan struct{}, eventLoopSignalCap),
 		errorChan:       make(chan error, errorChanCap),
-		tickers:         make([]*time.Ticker, 0),
 		Configs:         c,
 	}
 
 	w.waiters = sync.NewCond(&w.mx)
 	w.concurrency.Store(c.concurrency)
-
-	if c.ctx != nil {
-		w.ctx, w.cancel = context.WithCancel(c.ctx)
-	}
+	w.initContext(c.ctx)
 
 	return w
 }
@@ -306,18 +295,22 @@ func newResultWorker[T, R any](wf func(j iResultJob[T, R]), configs ...any) *wor
 		metrics:         newMetrics(),
 		eventLoopSignal: make(chan struct{}, eventLoopSignalCap),
 		errorChan:       make(chan error, errorChanCap),
-		tickers:         make([]*time.Ticker, 0),
 		Configs:         c,
 	}
 
 	w.waiters = sync.NewCond(&w.mx)
 	w.concurrency.Store(c.concurrency)
-
-	if c.ctx != nil {
-		w.ctx, w.cancel = context.WithCancel(c.ctx)
-	}
+	w.initContext(c.ctx)
 
 	return w
+}
+
+func (w *worker[T, JobType]) initContext(parentCtx context.Context) {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	w.ctx, w.cancel = context.WithCancel(parentCtx)
+	w.Configs.ctx = parentCtx
 }
 
 func (w *worker[T, JobType]) configs() configs {
@@ -340,28 +333,13 @@ func (w *worker[T, JobType]) releaseWaiters(processing uint32) {
 	if w.status.CompareAndSwap(pausing, paused) {
 		return
 	}
-
-	switch w.status.Load() {
-	case stopping, restarting:
-		// For stopping or restarting, perform full cleanup and set status to stopped.
-		w.stopTickers()
-		w.closeChannels()
-		w.removeAllWorkers()
-		w.status.Store(stopped)
-
-		if w.cancel != nil {
-			w.cancel()
-		}
-	}
 }
 
 func (w *worker[T, JobType]) sendError(err error) {
-	w.mx.RLock()
 	select {
 	case w.errorChan <- err:
 	default:
 	}
-	w.mx.RUnlock()
 }
 
 func (w *worker[T, JobType]) Metrics() Metrics {
@@ -390,12 +368,10 @@ func (w *worker[T, JobType]) Wait() {
 			if w.queues.Len() == 0 && w.curProcessing.Load() == 0 {
 				return
 			}
-		case paused, stopped:
+		case paused, stopped, pausing, stopping:
 			if w.curProcessing.Load() == 0 {
 				return
 			}
-		case pausing, stopping, restarting:
-			// Wait until the transition completes.
 		default:
 			return
 		}
@@ -546,8 +522,12 @@ func (w *worker[T, JobType]) initPoolNode() *linkedlist.Node[pool.Node[JobType]]
 		}
 		w.metrics.incCompleted()
 		w.freePoolNode(node)
-		w.releaseWaiters(w.curProcessing.Add(^uint32(0)))
-		w.notifyToPullNextJobs()
+		processing := w.curProcessing.Add(^uint32(0))
+		w.releaseWaiters(processing)
+
+		if processing < w.concurrency.Load() {
+			w.notifyToPullNextJobs()
+		}
 	})
 
 	return node
@@ -555,14 +535,12 @@ func (w *worker[T, JobType]) initPoolNode() *linkedlist.Node[pool.Node[JobType]]
 
 // notifyToPullNextJobs notifies the pullNextJobs function to process the next Job.
 func (w *worker[T, JobType]) notifyToPullNextJobs() {
-	w.mx.RLock()
 	select {
 	case w.eventLoopSignal <- struct{}{}:
 	default:
 		// This default case means the eventLoopSignal buffer is full or
 		// no one is listening. This is generally fine as it's a non-blocking send.
 	}
-	w.mx.RUnlock()
 }
 
 // numMinIdleWorkers returns the number of idle workers to keep based on concurrency and config percentage
@@ -581,44 +559,34 @@ func (w *worker[T, JobType]) goRemoveIdleWorkers() {
 	}
 
 	ticker := time.NewTicker(interval)
-	w.mx.Lock()
-	w.tickers = append(w.tickers, ticker)
-	w.mx.Unlock()
 
-	go func() {
-		for range ticker.C {
-			// Calculate the target number of idle workers
-			targetIdleWorkers := w.numMinIdleWorkers()
+	go func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				// Calculate the target number of idle workers
+				targetIdleWorkers := w.numMinIdleWorkers()
 
-			// if the number of idle workers is less than or equal to the target, continue
-			if w.pool.Len() <= targetIdleWorkers {
-				continue
-			}
+				// if the number of idle workers is less than or equal to the target, continue
+				if w.pool.Len() <= targetIdleWorkers {
+					continue
+				}
 
-			nodes := w.pool.NodeSlice()
-			// If we have more nodes than our target, close the excess ones
-			for _, node := range nodes[targetIdleWorkers:] {
-				if node.Value.GetLastUsed().Add(interval).Before(time.Now()) &&
-					!(node.Next() == nil && node.Prev() == nil) { // if both nil, it means the node is not in the list and not idle
-					w.pool.Remove(node)
-					node.Value.Stop()
-					w.pool.Cache.Put(node)
+				nodes := w.pool.NodeSlice()
+				// If we have more nodes than our target, close the excess ones
+				for _, node := range nodes[targetIdleWorkers:] {
+					if node.Value.GetLastUsed().Add(interval).Before(time.Now()) &&
+						!(node.Next() == nil && node.Prev() == nil) { // if both nil, it means the node is not in the list and not idle
+						w.pool.Remove(node)
+						node.Value.Stop()
+						w.pool.Cache.Put(node)
+					}
 				}
 			}
 		}
-	}()
-}
-
-func (w *worker[T, JobType]) goListenToContext() {
-	if w.ctx == nil {
-		return
-	}
-
-	// Capture context locally to avoid race with Restart() modifying w.ctx
-	go func(c context.Context) {
-		<-c.Done()
-
-		w.Stop()
 	}(w.ctx)
 }
 
@@ -626,40 +594,25 @@ func (w *worker[T, JobType]) goListenToContext() {
 // It continuously checks if the worker is running, has available capacity, and if there are jobs in the queue
 // When all conditions are met, it processes the next job in the queue
 func (w *worker[T, JobType]) goEventLoop() {
-	go func(signal <-chan struct{}) {
-		for range signal {
-			for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
-				if err := w.processNextJob(); err != nil {
-					w.sendError(err)
+	go func(ctx context.Context, signal <-chan struct{}) {
+		for {
+			select {
+			case <-ctx.Done():
+				w.status.Store(stopping)
+				w.Wait()
+				w.removeAllWorkers()
+				w.status.Store(stopped)
+				w.waiters.Broadcast()
+				return
+			case <-signal:
+				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
+					if err := w.processNextJob(); err != nil {
+						w.sendError(err)
+					}
 				}
 			}
 		}
-	}(w.eventLoopSignal)
-}
-
-func (w *worker[T, JobType]) stopTickers() {
-	w.mx.Lock()
-	defer w.mx.Unlock()
-
-	for _, ticker := range w.tickers {
-		ticker.Stop()
-	}
-
-	w.tickers = make([]*time.Ticker, 0)
-}
-
-func (w *worker[T, JobType]) closeChannels() {
-	w.mx.Lock()
-	defer w.mx.Unlock()
-
-	if w.eventLoopSignal != nil {
-		close(w.eventLoopSignal)
-		w.eventLoopSignal = nil
-	}
-	if w.errorChan != nil {
-		close(w.errorChan)
-		w.errorChan = nil
-	}
+	}(w.ctx, w.eventLoopSignal)
 }
 
 // removeAllWorkers removes all nodes from the list and closes the pool nodes
@@ -669,24 +622,6 @@ func (w *worker[T, JobType]) removeAllWorkers() {
 		node.Value.Stop()
 		w.pool.Cache.Put(node)
 	}
-}
-
-func (w *worker[T, JobType]) start() error {
-	if w.IsActive() {
-		return ErrRunningWorker
-	}
-
-	defer w.notifyToPullNextJobs()
-	defer w.status.Store(idle)
-
-	w.goEventLoop()
-	w.goRemoveIdleWorkers()
-	w.goListenToContext()
-
-	// init the first worker by default
-	w.pool.PushNode(w.initPoolNode())
-
-	return nil
 }
 
 func (w *worker[T, JobType]) TunePool(concurrency int) error {
@@ -741,6 +676,10 @@ func (w *worker[T, JobType]) NumIdleWorkers() int {
 	return w.pool.Len()
 }
 
+func (w *worker[T, JobType]) NumPending() int {
+	return w.queues.Len()
+}
+
 func (w *worker[T, JobType]) Pause() error {
 	s := w.status.Load()
 
@@ -762,6 +701,42 @@ func (w *worker[T, JobType]) Pause() error {
 	return w.getStatusError()
 }
 
+func (w *worker[T, JobType]) Resume() error {
+	if w.IsStopped() {
+		return ErrWorkerStopped
+	}
+
+	if w.status.Load() == initiated {
+		return w.start()
+	}
+
+	if w.IsActive() {
+		return ErrRunningWorker
+	}
+
+	w.status.Store(idle)
+	w.notifyToPullNextJobs()
+
+	return nil
+}
+
+func (w *worker[T, JobType]) start() error {
+	if w.IsActive() {
+		return ErrRunningWorker
+	}
+
+	defer w.notifyToPullNextJobs()
+	defer w.status.Store(idle)
+
+	w.goEventLoop()
+	w.goRemoveIdleWorkers()
+
+	// init the first worker by default
+	w.pool.PushNode(w.initPoolNode())
+
+	return nil
+}
+
 func (w *worker[T, JobType]) Stop() error {
 	s := w.status.Load()
 
@@ -771,16 +746,7 @@ func (w *worker[T, JobType]) Stop() error {
 
 	for _, from := range []status{running, idle, pausing, paused} {
 		if w.status.CompareAndSwap(from, stopping) {
-			if w.NumProcessing() == 0 {
-				w.stopTickers()
-				w.closeChannels()
-				w.removeAllWorkers()
-				w.status.Store(stopped)
-
-				if w.cancel != nil {
-					w.cancel()
-				}
-			}
+			w.cancel()
 			return nil
 		}
 	}
@@ -788,83 +754,16 @@ func (w *worker[T, JobType]) Stop() error {
 	return w.getStatusError()
 }
 
-func (w *worker[T, JobType]) NumPending() int {
-	return w.queues.Len()
-}
-
 func (w *worker[T, JobType]) Restart() error {
-	if w.status.Load() == restarting {
-		return nil
-	}
-
-	needsCleanup, err := w.transitionToRestarting()
-	if err != nil {
+	if err := w.Stop(); err != nil {
 		return err
 	}
 
-	if needsCleanup {
-		w.stopTickers()
-		w.closeChannels()
-	}
+	w.WaitUntilStopped()
 
-	w.mx.Lock()
-	w.eventLoopSignal = make(chan struct{}, eventLoopSignalCap)
-	w.errorChan = make(chan error, errorChanCap)
+	w.ctx, w.cancel = context.WithCancel(w.Configs.ctx)
 
-	if w.ctx != nil {
-		w.cancel()
-		w.ctx, w.cancel = context.WithCancel(w.Configs.ctx)
-	}
-	w.mx.Unlock()
-
-	if err := w.start(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (w *worker[T, JobType]) transitionToRestarting() (needsCleanup bool, _ error) {
-	if w.status.CompareAndSwap(idle, restarting) {
-		w.removeAllWorkers()
-		return true, nil
-	}
-
-	if w.status.CompareAndSwap(paused, restarting) {
-		w.removeAllWorkers()
-		return true, nil
-	}
-
-	if w.status.CompareAndSwap(running, restarting) {
-		if w.NumProcessing() > 0 {
-			w.Wait()
-		} else {
-			w.removeAllWorkers()
-		}
-		return true, nil
-	}
-
-	if w.status.CompareAndSwap(stopped, restarting) {
-		return false, nil
-	}
-
-	switch s := w.status.Load(); s {
-	case pausing:
-		w.WaitUntilPaused()
-		if !w.status.CompareAndSwap(paused, restarting) {
-			return false, w.getStatusError()
-		}
-		w.removeAllWorkers()
-		return true, nil
-	case stopping:
-		w.WaitUntilStopped()
-		if !w.status.CompareAndSwap(stopped, restarting) {
-			return false, w.getStatusError()
-		}
-		return false, nil
-	default:
-		return false, w.getStatusError()
-	}
+	return w.start()
 }
 
 func (w *worker[T, JobType]) IsPaused() bool {
@@ -898,8 +797,6 @@ func (w *worker[T, JobType]) getStatusError() error {
 		return ErrWorkerPausing
 	case stopping:
 		return ErrWorkerStopping
-	case restarting:
-		return ErrWorkerRestarting
 	case running, idle:
 		return ErrRunningWorker
 	default:
@@ -915,8 +812,6 @@ func (w *worker[T, JobType]) Status() string {
 		return "Idle"
 	case running:
 		return "Running"
-	case restarting:
-		return "Restarting"
 	case pausing:
 		return "Pausing"
 	case paused:
@@ -932,25 +827,6 @@ func (w *worker[T, JobType]) Status() string {
 
 func (w *worker[T, JobType]) NumProcessing() int {
 	return int(w.curProcessing.Load())
-}
-
-func (w *worker[T, JobType]) Resume() error {
-	if w.IsStopped() {
-		return ErrWorkerStopped
-	}
-
-	if w.status.Load() == initiated {
-		return w.start()
-	}
-
-	if w.IsActive() {
-		return ErrRunningWorker
-	}
-
-	w.status.Store(idle)
-	w.notifyToPullNextJobs()
-
-	return nil
 }
 
 func (w *worker[T, JobType]) Context() context.Context {
@@ -984,5 +860,10 @@ func (w *worker[T, JobType]) StopAndWait() error {
 func (w *worker[T, JobType]) WaitAndStop() error {
 	w.Wait()
 
-	return w.Stop()
+	if err := w.Stop(); err != nil {
+		return err
+	}
+
+	w.WaitUntilStopped()
+	return nil
 }

--- a/worker.go
+++ b/worker.go
@@ -701,6 +701,10 @@ func (w *worker[T, JobType]) Resume() error {
 		return nil
 	}
 
+	if w.IsActive() {
+		return nil
+	}
+
 	return w.getStatusError()
 }
 

--- a/worker.go
+++ b/worker.go
@@ -700,12 +700,12 @@ func (w *worker[T, JobType]) Resume() error {
 		return ErrWorkerStopped
 	}
 
-	if w.status.Load() == initiated {
-		return w.start()
-	}
-
 	if w.IsActive() {
 		return ErrRunningWorker
+	}
+
+	if !w.IsPaused() {
+		return ErrNotRunningWorker
 	}
 
 	w.status.Store(idle)

--- a/worker.go
+++ b/worker.go
@@ -696,8 +696,7 @@ func (w *worker[T, JobType]) Pause() error {
 }
 
 func (w *worker[T, JobType]) Resume() error {
-	if w.IsPaused() {
-		w.status.Store(idle)
+	if w.status.CompareAndSwap(paused, idle) {
 		w.notifyToPullNextJobs()
 		return nil
 	}

--- a/worker.go
+++ b/worker.go
@@ -131,6 +131,14 @@ type Worker interface {
 	//
 	// Once Paused, no new jobs are processed from the queue. Use Resume()
 	// to resume processing, or PauseAndWait() to block until fully paused.
+	//
+	// Pause is idempotent: calling Pause on an already Paused or Pausing
+	// worker returns nil.
+	//
+	// Errors:
+	//   - ErrWorkerStopped: worker is in the Stopped state.
+	//   - ErrWorkerStopping: worker is in the Stopping state.
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
 	Pause() error
 
 	// Stop initiates a graceful shutdown of the worker.
@@ -142,15 +150,51 @@ type Worker interface {
 	//
 	// A stopped worker cannot be resumed; use Restart() instead.
 	// Use StopAndWait() to block until fully stopped.
+	//
+	// Stop is idempotent: calling Stop on an already Stopped or Stopping
+	// worker returns nil.
+	//
+	// Errors:
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
+	//   - ErrWorkerStopped: worker is already in the Stopped state
+	//     (returned when called from an invalid intermediate state; the
+	//     idempotent path above returns nil for Stopped/Stopping).
 	Stop() error
 	// Restart gracefully restarts the worker, preserving any pending
 	// jobs in the queue. It stops the worker, waits for it to reach
 	// Stopped, recreates the internal context, and starts again.
+	//
+	// Restart works from any valid state: Running, Idle, Pausing, Paused,
+	// Stopping, or Stopped. It transparently handles the case where another
+	// goroutine already restarted the worker by returning ErrRunningWorker.
+	//
+	// Errors:
+	//   - ErrRunningWorker: worker is already active (concurrent restart).
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
+	//   - Errors from Stop(): see Stop's error documentation.
 	Restart() error
 	// Resume resumes a paused worker and begins processing pending
-	// jobs from the queue. This has no effect on a stopped worker —
-	// use Restart() instead.
+	// jobs from the queue.
+	//
+	// Resume is idempotent: calling Resume on an already active (Running or
+	// Idle) worker returns nil.
+	//
+	// Errors:
+	//   - ErrWorkerStopped: worker is in the Stopped state. Use Restart().
+	//   - ErrWorkerStopping: worker is in the Stopping state.
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
 	Resume() error
+	// Start begins processing jobs from the bound queues.
+	// When WithAutoRun is true (the default), the worker starts automatically
+	// after creation and this method returns ErrRunningWorker.
+	// Use WithAutoRun(false) to create a worker in an initiated state,
+	// then call Start() manually when ready.
+	//
+	// Errors:
+	//   - ErrRunningWorker: worker is already active (Running or Idle).
+	//   - ErrNotRunningWorker: worker is in an unexpected state
+	//     (not Initiated or any other valid start state).
+	Start() error
 	// WaitUntilFinished waits until all pending jobs are processed and the worker
 	// has no in-flight work. This is an alias for Wait().
 	//
@@ -254,6 +298,10 @@ func newWorker[T any](wf func(j iJob[T]), configs ...any) *worker[T, iJob[T]] {
 	w.concurrency.Store(c.concurrency)
 	w.initContext(c.ctx)
 
+	if c.autoRun {
+		w.Start()
+	}
+
 	return w
 }
 
@@ -275,6 +323,10 @@ func newErrWorker[T any](wf func(j iErrorJob[T]), configs ...any) *worker[T, iEr
 	w.concurrency.Store(c.concurrency)
 	w.initContext(c.ctx)
 
+	if c.autoRun {
+		w.Start()
+	}
+
 	return w
 }
 
@@ -295,6 +347,10 @@ func newResultWorker[T, R any](wf func(j iResultJob[T, R]), configs ...any) *wor
 	w.waiters = sync.NewCond(&w.mx)
 	w.concurrency.Store(c.concurrency)
 	w.initContext(c.ctx)
+
+	if c.autoRun {
+		w.Start()
+	}
 
 	return w
 }
@@ -378,7 +434,7 @@ func (w *worker[T, JobType]) WaitUntilIdle() {
 	defer w.mx.Unlock()
 
 	for {
-		if w.status.Load() == idle && w.queues.Len() == 0 {
+		if w.status.Load() == idle && w.queues.Len() == 0 && w.curProcessing.Load() == 0 {
 			return
 		}
 
@@ -408,6 +464,14 @@ func (w *worker[T, JobType]) Errs() <-chan error {
 	return w.errorChan
 }
 
+func (w *worker[T, JobType]) undoProcessingIncrement() {
+	processing := w.curProcessing.Add(^uint32(0))
+	w.releaseWaiters(processing)
+	if processing < w.concurrency.Load() {
+		w.notifyToPullNextJobs()
+	}
+}
+
 // processNextJob processes the next Job in the queue.
 func (w *worker[T, JobType]) processNextJob() error {
 	queue, err := w.queues.next()
@@ -415,6 +479,9 @@ func (w *worker[T, JobType]) processNextJob() error {
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrGetNextQueue, err)
 	}
+
+	w.curProcessing.Add(1)
+	w.status.CompareAndSwap(idle, running)
 
 	var (
 		v     any
@@ -430,42 +497,41 @@ func (w *worker[T, JobType]) processNextJob() error {
 	}
 
 	if !ok {
+		w.undoProcessingIncrement()
 		return ErrFailedToDequeue
 	}
 
 	var j JobType
 
-	// check the type of the value
-	// and cast it to the appropriate job type
 	switch value := v.(type) {
 	case JobType:
 		j = value
 	case []byte:
 		var err error
 		if v, err = parseToJob[T](value); err != nil {
+			w.undoProcessingIncrement()
 			return err
 		}
 
 		if j, ok = v.(JobType); !ok {
+			w.undoProcessingIncrement()
 			return ErrFailedToCastJob
 		}
 
 		j.setInternalQueue(queue)
 	default:
+		w.undoProcessingIncrement()
 		return ErrFailedToCastJob
 	}
 
 	if j.IsClosed() {
+		w.undoProcessingIncrement()
 		return nil
 	}
 
-	w.curProcessing.Add(1)
 	j.changeStatus(processing)
 	j.setAckId(ackId)
-	// if worker is idle, change the status to running
-	w.status.CompareAndSwap(idle, running)
 
-	// then job will be process by the processSingleJob function inside spawnWorker
 	w.sendToNextChannel(j)
 
 	return nil
@@ -682,12 +748,15 @@ func (w *worker[T, JobType]) Pause() error {
 	}
 
 	if w.status.CompareAndSwap(idle, paused) {
+		// won't Broadcast from releaseWaiters
+		w.waiters.Broadcast()
 		return nil
 	}
 
 	if w.status.CompareAndSwap(running, pausing) {
-		if w.NumProcessing() == 0 {
-			w.status.CompareAndSwap(pausing, paused)
+		if w.NumProcessing() == 0 && w.status.CompareAndSwap(pausing, paused) {
+			// won't Broadcast from releaseWaiters
+			w.waiters.Broadcast()
 		}
 		return nil
 	}
@@ -697,6 +766,7 @@ func (w *worker[T, JobType]) Pause() error {
 
 func (w *worker[T, JobType]) Resume() error {
 	if w.status.CompareAndSwap(paused, idle) {
+		w.waiters.Broadcast()
 		w.notifyToPullNextJobs()
 		return nil
 	}
@@ -708,7 +778,7 @@ func (w *worker[T, JobType]) Resume() error {
 	return w.getStatusError()
 }
 
-func (w *worker[T, JobType]) start() error {
+func (w *worker[T, JobType]) Start() error {
 	w.mx.Lock()
 	defer w.mx.Unlock()
 
@@ -738,7 +808,9 @@ func (w *worker[T, JobType]) Stop() error {
 
 	for _, from := range []status{running, idle, pausing, paused} {
 		if w.status.CompareAndSwap(from, stopping) {
+			w.mx.Lock()
 			w.cancel()
+			w.mx.Unlock()
 			return nil
 		}
 	}
@@ -751,25 +823,20 @@ func (w *worker[T, JobType]) Restart() error {
 		return err
 	}
 
-	// Wait for the worker to reach a terminal state (stopped or active).
-	// If another goroutine already restarted this worker while we were
-	// waiting, IsActive() will be true and we return ErrRunningWorker.
-	// sync.Cond.Wait() atomically releases w.mx and re-acquires it on wake-up.
 	w.mx.Lock()
 	for !w.IsStopped() && !w.IsActive() {
 		w.waiters.Wait()
 	}
+
 	if w.IsActive() {
 		w.mx.Unlock()
 		return ErrRunningWorker
 	}
 
-	// Create a new context before releasing the lock so that start()
-	// and the event loop goroutine see the updated context.
 	w.ctx, w.cancel = context.WithCancel(w.Configs.ctx)
 	w.mx.Unlock()
 
-	return w.start()
+	return w.Start()
 }
 
 func (w *worker[T, JobType]) IsPaused() bool {

--- a/worker.go
+++ b/worker.go
@@ -119,6 +119,10 @@ type Worker interface {
 	Metrics() Metrics
 	// TunePool adjusts the concurrency (pool size) of the worker
 	// up or down. This takes effect immediately for new jobs.
+	//
+	// Errors:
+	//   - ErrSameConcurrency: worker already has this concurrency value.
+	//   - see getStatusError() for additional state-specific errors.
 	TunePool(concurrency int) error
 	// Pause initiates a graceful pause of the worker.
 	//
@@ -155,9 +159,6 @@ type Worker interface {
 	//
 	// Errors:
 	//   - ErrNotRunningWorker: worker is in the Initiated state.
-	//   - ErrWorkerStopped: worker is already in the Stopped state
-	//     (returned when called from an invalid intermediate state; the
-	//     idempotent path above returns nil for Stopped/Stopping).
 	Stop() error
 	// Restart gracefully restarts the worker, preserving any pending
 	// jobs in the queue. It stops the worker, waits for it to reach
@@ -181,6 +182,7 @@ type Worker interface {
 	// Errors:
 	//   - ErrWorkerStopped: worker is in the Stopped state. Use Restart().
 	//   - ErrWorkerStopping: worker is in the Stopping state.
+	//   - ErrWorkerPausing: worker is in the Pausing state.
 	//   - ErrNotRunningWorker: worker is in the Initiated state.
 	Resume() error
 	// Start begins processing jobs from the bound queues.
@@ -189,10 +191,15 @@ type Worker interface {
 	// Use WithAutoRun(false) to create a worker in an initiated state,
 	// then call Start() manually when ready.
 	//
+	// Start only accepts initiated or stopped states. For all other states
+	// that still have a running event loop, it returns the corresponding
+	// status error.
+	//
 	// Errors:
 	//   - ErrRunningWorker: worker is already active (Running or Idle).
-	//   - ErrNotRunningWorker: worker is in an unexpected state
-	//     (not Initiated or any other valid start state).
+	//   - ErrWorkerPaused: worker is in the Paused state. Use Resume().
+	//   - ErrWorkerStopping: worker is in the Stopping state.
+	//   - ErrWorkerPausing: worker is in the Pausing state.
 	Start() error
 	// WaitUntilFinished waits until all pending jobs are processed and the worker
 	// has no in-flight work. This is an alias for Wait().
@@ -252,6 +259,9 @@ type Worker interface {
 	//
 	// This is equivalent to calling Wait(), Stop(), and WaitUntilStopped().
 	// Use this when you want to drain the queue before shutting down.
+	//
+	// Errors:
+	//   - see Stop() for error documentation.
 	WaitAndStop() error
 	// StopAndWait initiates a graceful stop and blocks until the worker
 	// reaches the Stopped state.
@@ -259,12 +269,18 @@ type Worker interface {
 	// This is equivalent to calling Stop() followed by WaitUntilStopped().
 	// If there are in-flight jobs, this blocks until they complete and
 	// all worker goroutines are removed.
+	//
+	// Errors:
+	//   - see Stop() for error documentation.
 	StopAndWait() error
 	// WaitAndPause waits until all pending jobs are processed and in-flight
 	// jobs complete, then pauses the worker.
 	//
 	// This is equivalent to calling Wait() followed by Pause(). Use this
 	// when you want to drain the queue before pausing.
+	//
+	// Errors:
+	//   - see Pause() for error documentation.
 	WaitAndPause() error
 	// PauseAndWait initiates a pause and blocks until the worker reaches
 	// the Paused state.
@@ -272,6 +288,9 @@ type Worker interface {
 	// This is equivalent to calling Pause() followed by WaitUntilPaused().
 	// If there are in-flight jobs, this blocks until they complete and
 	// the status transitions from Pausing to Paused.
+	//
+	// Errors:
+	//   - see Pause() for error documentation.
 	PauseAndWait() error
 
 	configs() configs
@@ -788,6 +807,11 @@ func (w *worker[T, JobType]) Start() error {
 
 	if w.IsActive() {
 		return ErrRunningWorker
+	}
+
+	s := w.status.Load()
+	if s != initiated && s != stopped {
+		return w.getStatusError()
 	}
 
 	w.goEventLoop()

--- a/worker.go
+++ b/worker.go
@@ -801,6 +801,10 @@ func (w *worker[T, JobType]) Start() error {
 		return w.getStatusError()
 	}
 
+	if s == stopped {
+		w.initContext(w.Configs.ctx)
+	}
+
 	w.goEventLoop()
 	w.goRemoveIdleWorkers()
 
@@ -847,8 +851,6 @@ func (w *worker[T, JobType]) Restart() error {
 		w.mx.Unlock()
 		return ErrRunningWorker
 	}
-
-	w.ctx, w.cancel = context.WithCancel(w.Configs.ctx)
 	w.mx.Unlock()
 
 	return w.Start()

--- a/worker.go
+++ b/worker.go
@@ -675,7 +675,7 @@ func (w *worker[T, JobType]) goEventLoop() {
 				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
 					if err := w.processNextJob(); err != nil {
 						if errors.Is(err, ErrGetNextQueue) {
-							continue
+							break
 						}
 						w.sendError(err)
 					}

--- a/worker.go
+++ b/worker.go
@@ -674,12 +674,10 @@ func (w *worker[T, JobType]) goEventLoop() {
 			case <-signal:
 				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
 					if err := w.processNextJob(); err != nil {
-						switch {
-						case errors.Is(err, ErrGetNextQueue):
-							break
-						default:
-							w.sendError(err)
+						if errors.Is(err, ErrGetNextQueue) {
+							continue
 						}
+						w.sendError(err)
 					}
 				}
 			}

--- a/worker_binder.go
+++ b/worker_binder.go
@@ -178,10 +178,8 @@ func (wb *workerBinder[T]) BindQueue(configs ...QueueConfigFunc) Queue[T] {
 }
 
 // WithQueue binds an existing queue implementation to the worker
-// It starts the worker and returns a Queue interface to interact with the queue
+// It returns a Queue interface to interact with the queue
 func (wb *workerBinder[T]) WithQueue(q IQueue, configs ...QueueConfigFunc) Queue[T] {
-	defer wb.start()
-
 	return newQueue(wb.worker, q, configs...)
 }
 
@@ -190,27 +188,20 @@ func (wb *workerBinder[T]) BindPriorityQueue(configs ...QueueConfigFunc) Priorit
 }
 
 func (wb *workerBinder[T]) WithPriorityQueue(pq IPriorityQueue, configs ...QueueConfigFunc) PriorityQueue[T] {
-	defer wb.start()
-
 	return newPriorityQueue(wb.worker, pq, configs...)
 }
 
 func (wb *workerBinder[T]) WithPersistentQueue(pq IPersistentQueue, configs ...QueueConfigFunc) PersistentQueue[T] {
-	defer wb.start()
-
 	return newPersistentQueue(wb.worker, pq, configs...)
 }
 
 func (wb *workerBinder[T]) WithPersistentPriorityQueue(pq IPersistentPriorityQueue, configs ...QueueConfigFunc) PersistentPriorityQueue[T] {
-	defer wb.start()
-
 	return newPersistentPriorityQueue(wb.worker, pq, configs...)
 }
 
 func (wb *workerBinder[T]) WithDistributedQueue(dq IDistributedQueue, configs ...QueueConfigFunc) DistributedQueue[T] {
 	c := loadQueueConfigs(configs...)
 	defer dq.Subscribe(wb.handleQueueSubscription)
-	defer wb.start()
 	defer wb.queues.Register(dq, c.priority)
 
 	return NewDistributedQueue[T](dq, configs...)
@@ -219,7 +210,6 @@ func (wb *workerBinder[T]) WithDistributedQueue(dq IDistributedQueue, configs ..
 func (wb *workerBinder[T]) WithDistributedPriorityQueue(dpq IDistributedPriorityQueue, configs ...QueueConfigFunc) DistributedPriorityQueue[T] {
 	c := loadQueueConfigs(configs...)
 	defer dpq.Subscribe(wb.handleQueueSubscription)
-	defer wb.start()
 	defer wb.queues.Register(dpq, c.priority)
 
 	return NewDistributedPriorityQueue[T](dpq, configs...)
@@ -308,8 +298,6 @@ func (ewb *errWorkerBinder[T]) BindQueue(configs ...QueueConfigFunc) ErrQueue[T]
 }
 
 func (ewb *errWorkerBinder[T]) WithQueue(q IQueue, configs ...QueueConfigFunc) ErrQueue[T] {
-	defer ewb.worker.start()
-
 	return newErrorQueue(ewb.worker, q, configs...)
 }
 
@@ -318,8 +306,6 @@ func (ewb *errWorkerBinder[T]) BindPriorityQueue(configs ...QueueConfigFunc) Err
 }
 
 func (ewb *errWorkerBinder[T]) WithPriorityQueue(pq IPriorityQueue, configs ...QueueConfigFunc) ErrPriorityQueue[T] {
-	defer ewb.worker.start()
-
 	return newErrorPriorityQueue(ewb.worker, pq, configs...)
 }
 
@@ -410,8 +396,6 @@ func (rwb *resultWorkerBinder[T, R]) BindQueue(configs ...QueueConfigFunc) Resul
 }
 
 func (rwb *resultWorkerBinder[T, R]) WithQueue(q IQueue, configs ...QueueConfigFunc) ResultQueue[T, R] {
-	defer rwb.worker.start()
-
 	return newResultQueue(rwb.worker, q, configs...)
 }
 
@@ -420,7 +404,5 @@ func (rwb *resultWorkerBinder[T, R]) BindPriorityQueue(configs ...QueueConfigFun
 }
 
 func (rwb *resultWorkerBinder[T, R]) WithPriorityQueue(pq IPriorityQueue, configs ...QueueConfigFunc) ResultPriorityQueue[T, R] {
-	defer rwb.worker.start()
-
 	return newResultPriorityQueue(rwb.worker, pq, configs...)
 }

--- a/worker_binder_test.go
+++ b/worker_binder_test.go
@@ -132,10 +132,6 @@ func TestHandleQueueSubscription(t *testing.T) {
 		// Get the worker binder to access handleQueueSubscription
 		binder := worker.(*workerBinder[string])
 
-		// Start the worker so it can process notifications
-		err := binder.worker.start()
-		assert.NoError(t, err, "Worker should start successfully")
-
 		// Test handleQueueSubscription directly
 		// This simulates what happens when a distributed queue notifies about an enqueued job
 		binder.handleQueueSubscription("enqueued")
@@ -335,6 +331,7 @@ func TestWorkerBinders(t *testing.T) {
 	t.Run("HasDistributedQueueMethod", func(t *testing.T) {
 		// Create a worker
 		w := newWorker(func(j iJob[string]) {})
+		defer w.Stop()
 
 		// Create a worker binder
 		binder := newQueues(w)
@@ -346,13 +343,12 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithDistributedPriorityQueue")
 		assert.True(t, exists, "WorkerBinder should have WithDistributedPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	t.Run("HasPersistentQueueMethod", func(t *testing.T) {
 		// Create a worker
 		w := newWorker(func(j iJob[string]) {})
+		defer w.Stop()
 
 		// Create a worker binder
 		binder := newQueues(w)
@@ -364,8 +360,6 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithPersistentPriorityQueue")
 		assert.True(t, exists, "WorkerBinder should have WithPersistentPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	t.Run("ResultHasQueueMethods", func(t *testing.T) {
@@ -373,6 +367,7 @@ func TestWorkerBinders(t *testing.T) {
 		w := newResultWorker(func(j iResultJob[string, int]) {
 			j.sendResult(len(j.Data()))
 		})
+		defer w.Stop()
 
 		// Create a result worker binder
 		binder := newResultQueues(w)
@@ -393,8 +388,6 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithPriorityQueue")
 		assert.True(t, exists, "ResultWorkerBinder should have WithPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	t.Run("ErrHasQueueMethods", func(t *testing.T) {
@@ -402,6 +395,7 @@ func TestWorkerBinders(t *testing.T) {
 		w := newErrWorker(func(j iErrorJob[string]) {
 			j.sendError(nil)
 		})
+		defer w.Stop()
 
 		// Create an error worker binder
 		binder := newErrQueues(w)
@@ -422,8 +416,6 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithPriorityQueue")
 		assert.True(t, exists, "ErrWorkerBinder should have WithPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	// Test result worker binder

--- a/worker_test.go
+++ b/worker_test.go
@@ -790,7 +790,7 @@ func TestWorkers(t *testing.T) {
 				assert.Less(t, w.pool.Len(), initialPoolSize, "Pool should be shrunk")
 			})
 
-			t.Run("Resume from initiated state", func(t *testing.T) {
+			t.Run("Resume from initiated state returns error", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
 				})
@@ -798,10 +798,7 @@ func TestWorkers(t *testing.T) {
 				assert.Equal(t, initiated, w.status.Load(), "Worker should be in initiated state")
 
 				err := w.Resume()
-				assert.NoError(t, err, "Resume should start worker from initiated state")
-				assert.True(t, w.IsActive(), "Worker should be running after Resume from initiated")
-
-				w.Stop()
+				assert.ErrorIs(t, err, ErrNotRunningWorker, "Resume should return error from initiated state")
 			})
 
 			t.Run("Resume when already running", func(t *testing.T) {

--- a/worker_test.go
+++ b/worker_test.go
@@ -1508,3 +1508,47 @@ func TestResumeConcurrency(t *testing.T) {
 	assert.False(t, w.IsPaused())
 	w.Stop()
 }
+
+func TestStartConcurrency(t *testing.T) {
+	w := newWorker(func(j iJob[string]) {
+		time.Sleep(1 * time.Millisecond)
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = w.start()
+		}()
+	}
+	wg.Wait()
+
+	assert.True(t, w.IsActive(), "worker should be active after concurrent start calls")
+	w.Stop()
+	w.WaitUntilStopped()
+}
+
+func TestRestartConcurrency(t *testing.T) {
+	w := newWorker(func(j iJob[string]) {
+		time.Sleep(1 * time.Millisecond)
+	})
+
+	err := w.start()
+	assert.NoError(t, err)
+	assert.True(t, w.IsActive())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = w.Restart()
+		}()
+	}
+	wg.Wait()
+
+	assert.True(t, w.IsActive(), "worker should remain active after concurrent restarts")
+	w.Stop()
+	w.WaitUntilStopped()
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -3,6 +3,7 @@ package varmq
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"reflect"
 	"strconv"
@@ -24,10 +25,9 @@ func TestWorkers(t *testing.T) {
 		// Group 1: Initialization tests
 		t.Run("Initialization", func(t *testing.T) {
 			t.Run("with default configuration", func(t *testing.T) {
-				// Create worker with default config
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 				assert := assert.New(t)
 
 				// Validate worker structure
@@ -124,14 +124,12 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, initialConcurrency, w.NumConcurrency(), "CurrentConcurrency should match initial value")
 
 				newConcurrency := 5
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(t, err, "TunePool should not return error")
 
 				assert.Equal(t, newConcurrency, w.NumConcurrency(), "CurrentConcurrency should return updated value after tuning")
@@ -143,7 +141,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("worker not running error", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				}, WithConcurrency(2))
+				}, WithConcurrency(2), WithAutoRun(false))
 				err := w.TunePool(4)
 				assert.Error(t, err, "TunePool should return error when worker is not running")
 				assert.Equal(t, ErrNotRunningWorker, err, "Should return specific 'worker not running' error")
@@ -154,14 +152,12 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, uint32(initialConcurrency), w.concurrency.Load(), "Initial concurrency should be set correctly")
 
 				newConcurrency := 5
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 
 				assert.Equal(t, newConcurrency, w.NumConcurrency(), "Concurrency should be updated to new value")
@@ -174,14 +170,12 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, uint32(initialConcurrency), w.concurrency.Load(), "Initial concurrency should be set correctly")
 
 				newConcurrency := 2
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 
 				assert.Equal(t, newConcurrency, w.NumConcurrency(), "Concurrency should be updated to new lower value")
@@ -194,11 +188,9 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
-				err = w.TunePool(0)
+				err := w.TunePool(0)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 				assert.Equal(t, withSafeConcurrency(0), w.concurrency.Load(), "Should use minimum safe concurrency when 0 is provided")
 			})
@@ -208,11 +200,9 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
-				err = w.TunePool(-5)
+				err := w.TunePool(-5)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 				assert.Equal(t, withSafeConcurrency(-5), w.concurrency.Load(), "Should use minimum safe concurrency when negative value is provided")
 			})
@@ -222,12 +212,10 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, uint32(initialConcurrency), w.concurrency.Load(), "Initial concurrency should be set correctly")
-				err = w.TunePool(initialConcurrency)
+				err := w.TunePool(initialConcurrency)
 				assert.ErrorIs(t, err, ErrSameConcurrency, "TunePool should return error when concurrency is the same")
 				assert.Equal(t, initialConcurrency, w.NumConcurrency(), "Concurrency should remain unchanged when set to same value")
 			})
@@ -241,6 +229,7 @@ func TestWorkers(t *testing.T) {
 				},
 					WithConcurrency(initialConcurrency),
 					WithIdleWorkerExpiryDuration(idleExpiryDuration),
+					WithAutoRun(false),
 				)
 
 				// Create a queue for testing
@@ -259,18 +248,18 @@ func TestWorkers(t *testing.T) {
 					q.Enqueue(newJob("job"+string(rune(i)), loadJobConfigs(w.configs())))
 				}
 
-			err := w.start()
-			assert := assert.New(t)
-			assert.NoError(err, "Worker should start without error")
+				assert := assert.New(t)
 
-			// Wait for jobs to be processed and pool to expand
-			w.Wait()
+				w.Start()
+
+				// Wait for jobs to be processed and pool to expand
+				w.Wait()
 
 				assert.Equal(w.pool.Len(), w.NumConcurrency(), "Pool size should be equal to the concurrency")
 
 				// Decrease concurrency
 				newConcurrency := 3
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(err, "TunePool should not return error when decreasing concurrency")
 
 				// Concurrency should be updated but pool size should not be manually shrunk
@@ -278,9 +267,8 @@ func TestWorkers(t *testing.T) {
 					"Concurrency should be updated to new lower value")
 
 				assert.Greater(w.pool.Len(), newConcurrency, "Pool size should be greater than the concurrency")
-				time.Sleep(idleExpiryDuration * 2)
-				// After the expiration the pool size must be equal to one
-				assert.Equal(w.pool.Len(), 1, "Pool size should be equal to one after expiration")
+
+				assert.Eventually(func() bool { return w.pool.Len() == 1 }, idleExpiryDuration*4, 10*time.Millisecond, "Pool size should be equal to one after expiration")
 			})
 
 		})
@@ -290,7 +278,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("worker state transitions", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 				assert := assert.New(t)
 
 				assert.Equal(initiated, w.status.Load(), "Initial status should be 'initiated'")
@@ -299,13 +287,13 @@ func TestWorkers(t *testing.T) {
 				assert.False(w.IsPaused(), "Worker should not be paused initially")
 				assert.False(w.IsStopped(), "Worker should not be stopped initially")
 
-				err := w.start()
+				err := w.Start()
 				assert.NoError(err, "Starting worker should not error")
 				assert.Equal(idle, w.status.Load(), "Status after start should be 'idle'")
 				assert.Equal("Idle", w.Status(), "Status string after start should be 'Idle'")
 				assert.True(w.IsActive(), "Worker should be running after start")
 
-				err = w.start()
+				err = w.Start()
 				assert.ErrorIs(err, ErrRunningWorker, "Starting an already running worker should error")
 
 				w.Pause()
@@ -314,16 +302,16 @@ func TestWorkers(t *testing.T) {
 				assert.True(w.IsPaused(), "Worker should be paused after Pause()")
 				assert.False(w.IsActive(), "Worker should not be running after Pause()")
 
-			err = w.Resume()
-			assert.NoError(err, "Resuming worker should not error")
-			assert.Equal(idle, w.status.Load(), "Status after resume should be 'idle'")
-			assert.Equal("Idle", w.Status(), "Status string after resume should be 'Idle'")
-			assert.True(w.IsActive(), "Worker should be running after Resume()")
+				err = w.Resume()
+				assert.NoError(err, "Resuming worker should not error")
+				assert.Equal(idle, w.status.Load(), "Status after resume should be 'idle'")
+				assert.Equal("Idle", w.Status(), "Status string after resume should be 'Idle'")
+				assert.True(w.IsActive(), "Worker should be running after Resume()")
 
-			err = w.Resume()
-			assert.NoError(err, "Resuming an already running worker should be idempotent")
+				err = w.Resume()
+				assert.NoError(err, "Resuming an already running worker should be idempotent")
 
-			w.Stop()
+				w.Stop()
 				w.WaitUntilStopped()
 				assert.Equal(stopped, w.status.Load(), "Status after stop should be 'stopped'")
 				assert.Equal("Stopped", w.Status(), "Status string after stop should be 'Stopped'")
@@ -338,53 +326,47 @@ func TestWorkers(t *testing.T) {
 			})
 
 			t.Run("restart functionality", func(t *testing.T) {
-				// Track job processing
 				var jobsProcessed atomic.Uint32
 
-				// Create a worker function that increments counter
 				workerFn := func(j iJob[int]) {
-					time.Sleep(5 * time.Millisecond) // Simulate work
+					time.Sleep(5 * time.Millisecond)
 					jobsProcessed.Add(1)
 				}
 
-				w := newWorker(workerFn)
+				w := newWorker(workerFn, WithAutoRun(false))
 				assert := assert.New(t)
 
-				// Create a queue for testing
 				q := queues.NewQueue[iJob[int]]()
 				w.queues.Register(q, math.MaxInt)
 
-				// Submit some initial jobs
+				w.Start()
+
 				for i := range 50 {
 					q.Enqueue(newJob(i, loadJobConfigs(w.configs())))
 				}
+				w.notifyToPullNextJobs()
 
-				// Start worker
-				err := w.start()
-				assert.NoError(err, "Starting worker should not error")
 				assert.True(w.IsActive(), "Worker should be running after start")
 
-				// Wait for some jobs to be processed
-				time.Sleep(50 * time.Millisecond)
+				w.Wait()
 
-				// Store the state before restart
-				processedBeforeRestart := jobsProcessed.Load()
-				assert.Greater(processedBeforeRestart, uint32(0), "Some jobs should be processed before restart")
+				assert.Equal(uint32(50), jobsProcessed.Load(), "All 50 jobs should be processed before restart")
 
-				// Restart the worker
-				err = w.Restart()
+				err := w.Restart()
 				assert.NoError(err, "Restarting worker should not error")
-
-				// Verify worker is running after restart
 				assert.True(w.IsActive(), "Worker should be running after restart")
 
-				// Wait for jobs to be processed after restart
-				time.Sleep(50 * time.Millisecond)
+				for i := range 50 {
+					q.Enqueue(newJob(i+50, loadJobConfigs(w.configs())))
+				}
+				w.notifyToPullNextJobs()
 
-				// Verify more jobs were processed after restart
-				assert.Greater(jobsProcessed.Load(), processedBeforeRestart, "More jobs should be processed after restart")
+				w.Wait()
 
-				// Clean up
+				assert.Eventually(func() bool {
+					return jobsProcessed.Load() == 100
+				}, 3*time.Second, 10*time.Millisecond, "All 100 jobs should be processed after restart")
+
 				w.Stop()
 			})
 
@@ -394,15 +376,12 @@ func TestWorkers(t *testing.T) {
 				})
 				assert := assert.New(t)
 
-				// Start and stop
-				err := w.start()
-				assert.NoError(err)
 				w.Stop()
 				w.WaitUntilStopped()
 				assert.True(w.IsStopped())
 
 				// Restart
-				err = w.Restart()
+				err := w.Restart()
 				assert.NoError(err, "Restarting a stopped worker should succeed")
 				assert.True(w.IsActive(), "Worker should be running after restart")
 
@@ -416,32 +395,27 @@ func TestWorkers(t *testing.T) {
 				})
 				assert := assert.New(t)
 
-				// Start and pause
-				err := w.start()
-				assert.NoError(err)
 				w.Pause()
 				assert.True(w.IsPaused())
 
 				// Stop
-				err = w.Stop()
+				err := w.Stop()
 				assert.NoError(err, "Stopping a paused worker should succeed")
 				w.WaitUntilStopped()
 				assert.True(w.IsStopped(), "Worker should be stopped")
 			})
 
 			t.Run("event loop processing error", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {})
+				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 				errChan := w.Errs()
 
-				// Register a mock queue that fails dequeue
 				mockQueue := mocks.NewMockPersistentQueue()
 				mockQueue.ShouldFailDequeue = true
-				// Need to put something in it to trigger the loop
 				mockQueue.Queue.Enqueue("trigger")
 
 				w.queues.Register(newQueue(w, mockQueue).internalQueue, math.MaxInt)
 
-				w.start()
+				w.Start()
 				defer w.Stop()
 
 				select {
@@ -453,22 +427,22 @@ func TestWorkers(t *testing.T) {
 			})
 
 			t.Run("redundant state transitions", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {})
+				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 				// initiated to paused: error
 				assert.ErrorIs(t, w.Pause(), ErrNotRunningWorker)
 				// initiated to stopped: error
 				assert.ErrorIs(t, w.Stop(), ErrNotRunningWorker)
 
-				w.start()
+				w.Start()
 				w.Pause()
 				assert.True(t, w.IsPaused())
 				// paused to paused: idempotent nil
 				assert.NoError(t, w.Pause())
 
-			w.Stop()
-			w.WaitUntilStopped()
-			assert.True(t, w.IsStopped())
-			// stopped to paused: error
+				w.Stop()
+				w.WaitUntilStopped()
+				assert.True(t, w.IsStopped())
+				// stopped to paused: error
 				assert.ErrorIs(t, w.Pause(), ErrWorkerStopped)
 				// stopped to stopped: idempotent nil
 				assert.NoError(t, w.Stop())
@@ -479,7 +453,6 @@ func TestWorkers(t *testing.T) {
 					w := newWorker(func(j iJob[string]) {
 						time.Sleep(10 * time.Millisecond)
 					})
-					w.start()
 					assert.NoError(t, w.Restart())
 					assert.True(t, w.IsActive())
 					w.Stop()
@@ -487,7 +460,6 @@ func TestWorkers(t *testing.T) {
 
 				t.Run("RestartPaused", func(t *testing.T) {
 					w := newWorker(func(j iJob[string]) {})
-					w.start()
 					w.Pause()
 					assert.NoError(t, w.Restart())
 					assert.True(t, w.IsActive())
@@ -533,7 +505,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("NumPending", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 				assert := assert.New(t)
 
 				// Create a queue
@@ -553,7 +525,7 @@ func TestWorkers(t *testing.T) {
 				assert.Equal(jobCount, w.NumPending(), "NumPending should reflect the number of jobs in the queue")
 
 				// Start worker to process jobs
-				err := w.start()
+				err := w.Start()
 				assert.NoError(err, "Worker should start without error")
 				defer w.Stop()
 
@@ -609,9 +581,6 @@ func TestWorkers(t *testing.T) {
 				defer w.Stop()
 				assert := assert.New(t)
 
-				err := w.start()
-				assert.NoError(err, "Starting worker should not error")
-
 				initialCount := w.pool.Len()
 				assert.Equal(initialCount, 1, "Should have one idle worker in the pool after start")
 
@@ -621,10 +590,13 @@ func TestWorkers(t *testing.T) {
 					w.pool.PushNode(node)
 				}
 
-				time.Sleep(expirySetting * 2)
-				assert.Less(w.NumIdleWorkers(), w.NumConcurrency(),
+				assert.Eventually(func() bool {
+					return w.NumIdleWorkers() < w.NumConcurrency()
+				}, expirySetting*4, 10*time.Millisecond,
 					"Number of idle workers should be reduced to less than concurrency")
-				assert.Equal(w.NumIdleWorkers(), w.numMinIdleWorkers(),
+				assert.Eventually(func() bool {
+					return w.NumIdleWorkers() == w.numMinIdleWorkers()
+				}, expirySetting*6, 10*time.Millisecond,
 					"Number of idle workers should be equal to min idle workers")
 			})
 		})
@@ -634,31 +606,25 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with IAcknowledgeable queue", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create a persistent queue that implements IAcknowledgeable
 				persistentQueue := mocks.NewMockPersistentQueue()
 				w.queues.Register(persistentQueue, math.MaxInt)
 				job := newJob("test-data", loadJobConfigs(w.configs()))
 				persistentQueue.Enqueue(job)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle queue
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
 
-				assert.Equal(t, 0, persistentQueue.Len(), "Item should be processed from queue")
+				assert.Eventually(t, func() bool { return persistentQueue.Len() == 0 }, 200*time.Millisecond, 5*time.Millisecond, "Item should be processed from queue")
 			})
 
 			t.Run("processNextJob with byte data parsing", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create a queue with byte data
 				job := newJob("test-data", loadJobConfigs(w.configs()))
 				jobBytes, _ := job.Json()
 
@@ -666,13 +632,8 @@ func TestWorkers(t *testing.T) {
 				testQueue.Enqueue(jobBytes)
 				w.queues.Register(testQueue, math.MaxInt)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle byte parsing
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Byte data should be parsed and processed")
 			})
@@ -680,9 +641,9 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with closed job", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create a closed job
 				job := newJob("test-data", loadJobConfigs(w.configs()))
 				job.Close()
 
@@ -690,13 +651,8 @@ func TestWorkers(t *testing.T) {
 				testQueue.Enqueue(job)
 				w.queues.Register(testQueue, math.MaxInt)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should skip closed job
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Closed job should be dequeued but not processed")
 			})
@@ -704,20 +660,15 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with invalid byte data", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create invalid byte data
 				testQueue := queues.NewQueue[any]()
 				testQueue.Enqueue([]byte("invalid json"))
 				w.queues.Register(testQueue, math.MaxInt)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle invalid byte data gracefully
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Invalid byte data should be dequeued")
 			})
@@ -725,20 +676,15 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with invalid type", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
-
-				// Create invalid type data
-				testQueue := queues.NewQueue[any]()
-				testQueue.Enqueue(123) // Invalid type
-				w.queues.Register(testQueue, math.MaxInt)
-
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
+				}, WithAutoRun(false))
 				defer w.Stop()
 
-				// Process should handle invalid type gracefully
+				testQueue := queues.NewQueue[any]()
+				testQueue.Enqueue(123)
+				w.queues.Register(testQueue, math.MaxInt)
+
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Invalid type should be dequeued")
 			})
@@ -748,8 +694,6 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				}, WithConcurrency(1))
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Create many idle workers to trigger stopping
@@ -771,8 +715,6 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				}, WithConcurrency(5))
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Add workers to the pool
@@ -784,7 +726,7 @@ func TestWorkers(t *testing.T) {
 				initialPoolSize := w.pool.Len()
 
 				// Shrink concurrency - should trigger pool shrinking
-				err = w.TunePool(2)
+				err := w.TunePool(2)
 				assert.NoError(t, err, "TunePool should not error")
 
 				// Pool should be shrunk
@@ -794,7 +736,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("Resume from initiated state returns error", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 
 				assert.Equal(t, initiated, w.status.Load(), "Worker should be in initiated state")
 
@@ -807,11 +749,9 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				})
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
-				err = w.Resume()
+				err := w.Resume()
 				assert.NoError(t, err, "Resume should be idempotent when already running")
 			})
 
@@ -820,10 +760,7 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				})
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-
-				err = w.Stop()
+				err := w.Stop()
 				assert.NoError(t, err, "Worker should stop without error")
 				w.WaitUntilStopped()
 
@@ -831,53 +768,11 @@ func TestWorkers(t *testing.T) {
 				assert.ErrorIs(t, err, ErrWorkerStopped, "Resume should return error when worker is stopped")
 			})
 
-			t.Run("processNextJob with empty queue", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {
-					time.Sleep(5 * time.Millisecond)
-				})
-
-				// Create an empty queue
-				testQueue := queues.NewQueue[any]()
-				w.queues.Register(testQueue, math.MaxInt)
-
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle empty queue gracefully
-				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
-			})
-
-			t.Run("processNextJob with byte parsing that creates wrong job type", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {
-					time.Sleep(5 * time.Millisecond)
-				})
-
-				// Create a job with different type that would cause type assertion to fail
-				job := newJob(123, loadJobConfigs(w.configs())) // int instead of string
-				jobBytes, _ := job.Json()
-
-				testQueue := queues.NewQueue[any]()
-				testQueue.Enqueue(jobBytes)
-				w.queues.Register(testQueue, math.MaxInt)
-
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle type mismatch gracefully
-				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
-			})
-
 			t.Run("TunePool edge case with empty pool", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
 				}, WithConcurrency(5))
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Clear the pool
@@ -888,7 +783,7 @@ func TestWorkers(t *testing.T) {
 				}
 
 				// Shrink concurrency with empty pool
-				err = w.TunePool(2)
+				err := w.TunePool(2)
 				assert.NoError(t, err, "TunePool should handle empty pool")
 			})
 
@@ -901,8 +796,6 @@ func TestWorkers(t *testing.T) {
 					WithMinIdleWorkerRatio(50),
 				)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Add nodes that are both in list and not in list to test edge cases
@@ -912,16 +805,12 @@ func TestWorkers(t *testing.T) {
 					w.pool.PushNode(node)
 				}
 
-				// Wait for idle worker removal to kick in
-				time.Sleep(30 * time.Millisecond)
-
-				// Should have cleaned up some workers
-				assert.LessOrEqual(t, w.pool.Len(), w.numMinIdleWorkers()+1, "Pool should be cleaned up")
+				assert.Eventually(t, func() bool { return w.pool.Len() <= w.numMinIdleWorkers()+1 }, 200*time.Millisecond, 5*time.Millisecond, "Pool should be cleaned up")
 			})
 
 			t.Run("processNextJob with parse failure", func(t *testing.T) {
 				mockQueue := mocks.NewMockPersistentQueue()
-				w := newWorker(func(j iJob[int]) {})
+				w := newWorker(func(j iJob[int]) {}, WithAutoRun(false))
 
 				mockQueue.Queue.Enqueue([]byte("invalid json"))
 
@@ -935,8 +824,7 @@ func TestWorkers(t *testing.T) {
 
 			t.Run("processNextJob with cast failure after parse", func(t *testing.T) {
 				mockQueue := mocks.NewMockPersistentQueue()
-				// use newErrWorker so JobType is iErrorJob[string]
-				w := newErrWorker(func(j iErrorJob[string]) {})
+				w := newErrWorker(func(j iErrorJob[string]) {}, WithAutoRun(false))
 
 				// Create a valid JSON that parseToJob will accept and return *job[string]
 				// *job[string] does NOT implement iErrorJob[string]
@@ -971,17 +859,11 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithContext(ctx))
 
-				assert := assert.New(t)
-				err := w.start()
-				assert.NoError(err)
-				assert.True(w.IsActive())
+				w.WaitUntilIdle()
 
-				// Cancel the context
 				cancel()
 
-				// Wait for the worker to stop
-				time.Sleep(50 * time.Millisecond)
-				assert.True(w.IsStopped(), "Worker should be stopped after context cancellation")
+				assert.Eventually(t, func() bool { return w.IsStopped() }, 500*time.Millisecond, 5*time.Millisecond, "Worker should be stopped after context cancellation")
 			})
 
 			t.Run("restart recreates context", func(t *testing.T) {
@@ -990,13 +872,11 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
 
 				assert := assert.New(t)
-				err := w.start()
-				assert.NoError(err)
 
 				// Verify context exists
 				assert.NotNil(w.Context())
 
-				err = w.Stop()
+				err := w.Stop()
 				assert.NoError(err)
 
 				err = w.Restart()
@@ -1132,9 +1012,9 @@ type mockJob struct {
 
 func TestStatusError(t *testing.T) {
 	tests := []struct {
-		name     string
-		status   status
-		wantErr  error
+		name    string
+		status  status
+		wantErr error
 	}{
 		{"paused returns ErrWorkerPaused", paused, ErrWorkerPaused},
 		{"stopped returns ErrWorkerStopped", stopped, ErrWorkerStopped},
@@ -1160,20 +1040,18 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Pause()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Pause()
 		assert.NoError(t, err)
-		assert.Equal(t, pausing, w.status.Load())
+		assert.Equal(t, pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 		err = w.Pause()
 		assert.NoError(t, err, "Pause on pausing state should be idempotent")
@@ -1187,18 +1065,16 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Stop()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Stop()
 		assert.NoError(t, err)
 		assert.Equal(t, stopping, w.status.Load())
 
@@ -1228,20 +1104,18 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Pause()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Pause()
 		assert.NoError(t, err)
-		assert.Equal(t, pausing, w.status.Load())
+		assert.Equal(t, pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 		done := make(chan struct{})
 		go func() {
@@ -1261,7 +1135,7 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		select {
 		case <-done:
 			assert.True(t, w.IsActive(), "Worker should be active after restart from pausing")
-		case <-time.After(2 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("Restart should complete after pausing completes")
 		}
 
@@ -1272,18 +1146,16 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Stop()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Stop()
 		assert.NoError(t, err)
 		assert.Equal(t, stopping, w.status.Load())
 
@@ -1305,7 +1177,7 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		select {
 		case <-done:
 			assert.True(t, w.IsActive(), "Worker should be active after restart from stopping")
-		case <-time.After(2 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("Restart should complete after stopping completes")
 		}
 	})
@@ -1334,10 +1206,8 @@ func (m *mockJob) Close() error {
 func TestPausePausingFastPath(t *testing.T) {
 	t.Run("Pause transitions directly to paused when no jobs processing", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
 
-		err = w.Pause()
+		err := w.Pause()
 		assert.NoError(t, err)
 		assert.Equal(t, paused, w.status.Load(), "Should transition directly to paused when idle")
 		assert.True(t, w.IsPaused())
@@ -1349,21 +1219,18 @@ func TestPausePausingFastPath(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
 
-		err := w.start()
-		assert.NoError(t, err)
-
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Pause()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Pause()
 		assert.NoError(t, err)
-		assert.Equal(t, pausing, w.status.Load(), "Should be pausing")
+		assert.Equal(t, pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 		close(blockCh)
 
@@ -1377,12 +1244,11 @@ func TestPausePausingFastPath(t *testing.T) {
 func TestRestartCoverage(t *testing.T) {
 	t.Run("Restart from idle with no processing", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
-		assert.True(t, w.IsIdle())
+		w.WaitUntilIdle()
 
-		err = w.Restart()
+		err := w.Restart()
 		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.True(t, w.IsActive())
 
 		w.Stop()
@@ -1390,9 +1256,8 @@ func TestRestartCoverage(t *testing.T) {
 
 	t.Run("Restart from paused", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
-		err = w.Pause()
+		w.WaitUntilIdle()
+		err := w.Pause()
 		assert.NoError(t, err)
 		assert.True(t, w.IsPaused())
 
@@ -1405,12 +1270,12 @@ func TestRestartCoverage(t *testing.T) {
 	t.Run("Restart with context cancels and recreates context", func(t *testing.T) {
 		ctx := t.Context()
 		w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
-		err := w.start()
-		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 
-		err = w.Restart()
+		err := w.Restart()
 		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 		assert.NoError(t, w.Context().Err(), "New context should not be cancelled")
 
@@ -1419,12 +1284,12 @@ func TestRestartCoverage(t *testing.T) {
 
 	t.Run("Restart without context does not panic", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 
-		err = w.Restart()
+		err := w.Restart()
 		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 
 		w.Stop()
@@ -1433,11 +1298,11 @@ func TestRestartCoverage(t *testing.T) {
 
 func TestStatusAllCases(t *testing.T) {
 	t.Run("Status returns correct string for all states", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
+		w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 
 		assert.Equal(t, "Initiated", w.Status())
 
-		w.start()
+		w.Start()
 		assert.Equal(t, "Idle", w.Status())
 
 		w.status.Store(running)
@@ -1462,7 +1327,7 @@ func TestStatusAllCases(t *testing.T) {
 
 func TestStopAndWaitErrorPath(t *testing.T) {
 	t.Run("StopAndWait returns error when Stop fails", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
+		w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 		err := w.StopAndWait()
 		assert.ErrorIs(t, err, ErrNotRunningWorker)
 	})
@@ -1472,8 +1337,6 @@ func TestReleaseWaitersCleanup(t *testing.T) {
 	t.Run("event loop performs full cleanup on context cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
-		err := w.start()
-		assert.NoError(t, err)
 		assert.NotNil(t, w.Context())
 
 		cancel()
@@ -1487,8 +1350,6 @@ func TestResumeConcurrency(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	})
 
-	err := w.start()
-	assert.NoError(t, err)
 	w.Pause()
 	w.WaitUntilPaused()
 	assert.True(t, w.IsPaused())
@@ -1512,14 +1373,14 @@ func TestResumeConcurrency(t *testing.T) {
 func TestStartConcurrency(t *testing.T) {
 	w := newWorker(func(j iJob[string]) {
 		time.Sleep(1 * time.Millisecond)
-	})
+	}, WithAutoRun(false))
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = w.start()
+			_ = w.Start()
 		}()
 	}
 	wg.Wait()
@@ -1534,12 +1395,10 @@ func TestRestartConcurrency(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	})
 
-	err := w.start()
-	assert.NoError(t, err)
-	assert.True(t, w.IsActive())
+	w.WaitUntilIdle()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1548,7 +1407,8 @@ func TestRestartConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.True(t, w.IsActive(), "worker should remain active after concurrent restarts")
+	w.WaitUntilIdle()
+	assert.True(t, w.IsActive(), "worker should be active after concurrent restarts")
 	w.Stop()
 	w.WaitUntilStopped()
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1479,4 +1480,37 @@ func TestReleaseWaitersCleanup(t *testing.T) {
 		w.WaitUntilStopped()
 		assert.True(t, w.IsStopped())
 	})
+}
+
+func TestResumeConcurrency(t *testing.T) {
+	w := newWorker(func(j iJob[string]) {
+		time.Sleep(5 * time.Millisecond)
+	})
+
+	err := w.start()
+	assert.NoError(t, err)
+	w.Pause()
+	w.WaitUntilPaused()
+	assert.True(t, w.IsPaused())
+
+	var wg sync.WaitGroup
+	successCount := atomic.Int32{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := w.Resume()
+			if err == nil {
+				successCount.Add(1)
+			} else {
+				assert.ErrorIs(t, err, ErrRunningWorker)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), successCount.Load(), "Exactly one Resume should succeed")
+	assert.True(t, w.IsIdle())
+	assert.False(t, w.IsPaused())
+	w.Stop()
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -314,16 +314,16 @@ func TestWorkers(t *testing.T) {
 				assert.True(w.IsPaused(), "Worker should be paused after Pause()")
 				assert.False(w.IsActive(), "Worker should not be running after Pause()")
 
-				err = w.Resume()
-				assert.NoError(err, "Resuming worker should not error")
-				assert.Equal(idle, w.status.Load(), "Status after resume should be 'idle'")
-				assert.Equal("Idle", w.Status(), "Status string after resume should be 'Idle'")
-				assert.True(w.IsActive(), "Worker should be running after Resume()")
+			err = w.Resume()
+			assert.NoError(err, "Resuming worker should not error")
+			assert.Equal(idle, w.status.Load(), "Status after resume should be 'idle'")
+			assert.Equal("Idle", w.Status(), "Status string after resume should be 'Idle'")
+			assert.True(w.IsActive(), "Worker should be running after Resume()")
 
-				err = w.Resume()
-				assert.ErrorIs(err, ErrRunningWorker, "Resuming an already running worker should error")
+			err = w.Resume()
+			assert.NoError(err, "Resuming an already running worker should be idempotent")
 
-				w.Stop()
+			w.Stop()
 				w.WaitUntilStopped()
 				assert.Equal(stopped, w.status.Load(), "Status after stop should be 'stopped'")
 				assert.Equal("Stopped", w.Status(), "Status string after stop should be 'Stopped'")
@@ -802,7 +802,7 @@ func TestWorkers(t *testing.T) {
 				assert.ErrorIs(t, err, ErrNotRunningWorker, "Resume should return error from initiated state")
 			})
 
-			t.Run("Resume when already running", func(t *testing.T) {
+			t.Run("Resume when already running is idempotent", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
 				})
@@ -812,7 +812,7 @@ func TestWorkers(t *testing.T) {
 				defer w.Stop()
 
 				err = w.Resume()
-				assert.ErrorIs(t, err, ErrRunningWorker, "Resume should return error when already running")
+				assert.NoError(t, err, "Resume should be idempotent when already running")
 			})
 
 			t.Run("Resume stopped worker", func(t *testing.T) {
@@ -1494,22 +1494,16 @@ func TestResumeConcurrency(t *testing.T) {
 	assert.True(t, w.IsPaused())
 
 	var wg sync.WaitGroup
-	successCount := atomic.Int32{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			err := w.Resume()
-			if err == nil {
-				successCount.Add(1)
-			} else {
-				assert.ErrorIs(t, err, ErrRunningWorker)
-			}
+			assert.NoError(t, err)
 		}()
 	}
 	wg.Wait()
 
-	assert.Equal(t, int32(1), successCount.Load(), "Exactly one Resume should succeed")
 	assert.True(t, w.IsIdle())
 	assert.False(t, w.IsPaused())
 	w.Stop()

--- a/worker_test.go
+++ b/worker_test.go
@@ -36,7 +36,6 @@ func TestWorkers(t *testing.T) {
 				assert.Equal(initiated, w.status.Load(), "status should be 'initiated'")
 				assert.NotNil(&w.queues, "queues should not be nil, expected null queue")
 				assert.False(reflect.ValueOf(w.eventLoopSignal).IsNil(), "eventLoopSignal should be initialized")
-				assert.NotNil(w.tickers, "tickers map should be initialized")
 				assert.NotNil(w.waiters, "waiters cond should be initialized")
 				assert.NotNil(w.pool, "worker pool should be initialized")
 				assert.Zero(w.pool.Len(), "pool should be empty initially")
@@ -324,6 +323,7 @@ func TestWorkers(t *testing.T) {
 				assert.ErrorIs(err, ErrRunningWorker, "Resuming an already running worker should error")
 
 				w.Stop()
+				w.WaitUntilStopped()
 				assert.Equal(stopped, w.status.Load(), "Status after stop should be 'stopped'")
 				assert.Equal("Stopped", w.Status(), "Status string after stop should be 'Stopped'")
 				assert.True(w.IsStopped(), "Worker should be stopped after Stop()")
@@ -370,18 +370,12 @@ func TestWorkers(t *testing.T) {
 				processedBeforeRestart := jobsProcessed.Load()
 				assert.Greater(processedBeforeRestart, uint32(0), "Some jobs should be processed before restart")
 
-				// Verify eventLoopSignal exists before restart
-				assert.False(reflect.ValueOf(w.eventLoopSignal).IsNil(), "eventLoopSignal should exist before restart")
-
 				// Restart the worker
 				err = w.Restart()
 				assert.NoError(err, "Restarting worker should not error")
 
 				// Verify worker is running after restart
 				assert.True(w.IsActive(), "Worker should be running after restart")
-
-				// Verify the eventLoopSignal was recreated
-				assert.False(reflect.ValueOf(w.eventLoopSignal).IsNil(), "eventLoopSignal should be recreated after restart")
 
 				// Wait for jobs to be processed after restart
 				time.Sleep(50 * time.Millisecond)
@@ -403,6 +397,7 @@ func TestWorkers(t *testing.T) {
 				err := w.start()
 				assert.NoError(err)
 				w.Stop()
+				w.WaitUntilStopped()
 				assert.True(w.IsStopped())
 
 				// Restart
@@ -429,6 +424,7 @@ func TestWorkers(t *testing.T) {
 				// Stop
 				err = w.Stop()
 				assert.NoError(err, "Stopping a paused worker should succeed")
+				w.WaitUntilStopped()
 				assert.True(w.IsStopped(), "Worker should be stopped")
 			})
 
@@ -468,9 +464,10 @@ func TestWorkers(t *testing.T) {
 				// paused to paused: idempotent nil
 				assert.NoError(t, w.Pause())
 
-				w.Stop()
-				assert.True(t, w.IsStopped())
-				// stopped to paused: error
+			w.Stop()
+			w.WaitUntilStopped()
+			assert.True(t, w.IsStopped())
+			// stopped to paused: error
 				assert.ErrorIs(t, w.Pause(), ErrWorkerStopped)
 				// stopped to stopped: idempotent nil
 				assert.NoError(t, w.Stop())
@@ -830,6 +827,7 @@ func TestWorkers(t *testing.T) {
 
 				err = w.Stop()
 				assert.NoError(t, err, "Worker should stop without error")
+				w.WaitUntilStopped()
 
 				err = w.Resume()
 				assert.ErrorIs(t, err, ErrWorkerStopped, "Resume should return error when worker is stopped")
@@ -958,9 +956,9 @@ func TestWorkers(t *testing.T) {
 
 		// Group 8: Context-related tests
 		t.Run("Context", func(t *testing.T) {
-			t.Run("returns nil when no context configured", func(t *testing.T) {
+			t.Run("returns default context when not configured", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {})
-				assert.Nil(t, w.Context(), "Context should be nil when not configured")
+				assert.NotNil(t, w.Context(), "Context should have a default background context")
 			})
 
 			t.Run("returns context when configured with WithContext", func(t *testing.T) {
@@ -1000,7 +998,6 @@ func TestWorkers(t *testing.T) {
 				// Verify context exists
 				assert.NotNil(w.Context())
 
-				// Stop and restart cleanly to avoid race with goListenToContext
 				err = w.Stop()
 				assert.NoError(err)
 
@@ -1145,7 +1142,6 @@ func TestStatusError(t *testing.T) {
 		{"stopped returns ErrWorkerStopped", stopped, ErrWorkerStopped},
 		{"pausing returns ErrWorkerPausing", pausing, ErrWorkerPausing},
 		{"stopping returns ErrWorkerStopping", stopping, ErrWorkerStopping},
-		{"restarting returns ErrWorkerRestarting", restarting, ErrWorkerRestarting},
 		{"running returns ErrRunningWorker", running, ErrRunningWorker},
 		{"idle returns ErrRunningWorker", idle, ErrRunningWorker},
 		{"initiated returns ErrNotRunningWorker", initiated, ErrNotRunningWorker},
@@ -1215,29 +1211,15 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		w.WaitUntilStopped()
 	})
 
-	t.Run("Restart is idempotent for restarting state", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
-		w.status.Store(restarting)
-
-		err := w.Restart()
-		assert.NoError(t, err, "Restart on restarting state should be idempotent")
-	})
-
 	t.Run("Pause returns status-specific errors", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
 
 		w.status.Store(stopping)
 		assert.ErrorIs(t, w.Pause(), ErrWorkerStopping)
-
-		w.status.Store(restarting)
-		assert.ErrorIs(t, w.Pause(), ErrWorkerRestarting)
 	})
 
 	t.Run("Stop returns status-specific errors", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-
-		w.status.Store(restarting)
-		assert.ErrorIs(t, w.Stop(), ErrWorkerRestarting)
 
 		// paused is a valid transition for Stop, should succeed
 		w.status.Store(paused)
@@ -1395,7 +1377,7 @@ func TestPausePausingFastPath(t *testing.T) {
 }
 
 func TestRestartCoverage(t *testing.T) {
-	t.Run("Restart from idle with no processing calls removeAllWorkers", func(t *testing.T) {
+	t.Run("Restart from idle with no processing", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
 		err := w.start()
 		assert.NoError(t, err)
@@ -1404,23 +1386,11 @@ func TestRestartCoverage(t *testing.T) {
 		err = w.Restart()
 		assert.NoError(t, err)
 		assert.True(t, w.IsActive())
+
 		w.Stop()
 	})
 
-	t.Run("Restart from stopped needs no cleanup", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
-		w.Stop()
-		assert.True(t, w.IsStopped())
-
-		err = w.Restart()
-		assert.NoError(t, err)
-		assert.True(t, w.IsActive())
-		w.Stop()
-	})
-
-	t.Run("Restart from paused needs cleanup", func(t *testing.T) {
+	t.Run("Restart from paused", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
 		err := w.start()
 		assert.NoError(t, err)
@@ -1453,11 +1423,11 @@ func TestRestartCoverage(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
 		err := w.start()
 		assert.NoError(t, err)
-		assert.Nil(t, w.Context())
+		assert.NotNil(t, w.Context())
 
 		err = w.Restart()
 		assert.NoError(t, err)
-		assert.Nil(t, w.Context())
+		assert.NotNil(t, w.Context())
 
 		w.Stop()
 	})
@@ -1487,9 +1457,6 @@ func TestStatusAllCases(t *testing.T) {
 		w.status.Store(stopped)
 		assert.Equal(t, "Stopped", w.Status())
 
-		w.status.Store(restarting)
-		assert.Equal(t, "Restarting", w.Status())
-
 		w.status.Store(99)
 		assert.Equal(t, "Unknown", w.Status())
 	})
@@ -1504,15 +1471,15 @@ func TestStopAndWaitErrorPath(t *testing.T) {
 }
 
 func TestReleaseWaitersCleanup(t *testing.T) {
-	t.Run("releaseWaiters performs full cleanup for stopping state with context", func(t *testing.T) {
-		ctx := context.Background()
+	t.Run("event loop performs full cleanup on context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
 		w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
 		err := w.start()
 		assert.NoError(t, err)
 		assert.NotNil(t, w.Context())
 
-		err = w.Stop()
-		assert.NoError(t, err)
+		cancel()
+		w.WaitUntilStopped()
 		assert.True(t, w.IsStopped())
 	})
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -976,13 +976,11 @@ func TestWorkers(t *testing.T) {
 func TestPublicWorkerErrors(t *testing.T) {
 	t.Run("ErrGetNextQueue can be detected with errors.Is", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
+		defer w.StopAndWait()
 
-		// Set an invalid strategy to trigger the error
-		w.queues.strategy = Strategy(99) // Invalid strategy
-
-		// Register a queue with some data to attempt processing
+		// Register an empty queue so next() returns ErrAllItemsEmpty,
+		// which processNextJob returns as ErrGetNextQueue.
 		mockQueue := mocks.NewMockPersistentQueue()
-		mockQueue.Queue.Enqueue("test")
 		w.queues.Register(mockQueue, math.MaxInt)
 
 		err := w.processNextJob()
@@ -993,6 +991,7 @@ func TestPublicWorkerErrors(t *testing.T) {
 	t.Run("ErrParseJob can be detected with errors.Is", func(t *testing.T) {
 		mockQueue := mocks.NewMockPersistentQueue()
 		w := newWorker(func(j iJob[int]) {})
+		defer w.StopAndWait()
 
 		mockQueue.Queue.Enqueue([]byte("invalid json"))
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -325,6 +325,58 @@ func TestWorkers(t *testing.T) {
 				assert.Equal("Unknown", w.Status(), "Status string for unknown status should be 'Unknown'")
 			})
 
+			t.Run("Start returns error for paused/pausing/stopping states", func(t *testing.T) {
+				blockCh := make(chan struct{})
+				w := newWorker(func(j iJob[string]) {
+					<-blockCh
+				}, WithAutoRun(false))
+				assert := assert.New(t)
+
+				q := queues.NewQueue[iJob[string]]()
+				w.queues.Register(q, math.MaxInt)
+
+				// Test Start on paused
+				w.Start()
+				w.Pause()
+				w.WaitUntilPaused()
+				err := w.Start()
+				assert.ErrorIs(err, ErrWorkerPaused, "Start() on paused worker should return ErrWorkerPaused")
+				w.Resume()
+				w.Stop()
+				w.WaitUntilStopped()
+
+				// Test Start on pausing
+				w2 := newWorker(func(j iJob[string]) {
+					<-blockCh
+				}, WithAutoRun(false))
+				q2 := queues.NewQueue[iJob[string]]()
+				w2.queues.Register(q2, math.MaxInt)
+				q2.Enqueue(newJob("job", loadJobConfigs(w2.configs())))
+				w2.Start()
+				assert.Eventually(func() bool { return w2.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+				w2.Pause()
+				err = w2.Start()
+				assert.ErrorIs(err, ErrWorkerPausing, "Start() on pausing worker should return ErrWorkerPausing")
+
+				// Test Start on stopping
+				w3 := newWorker(func(j iJob[string]) {
+					<-blockCh
+				}, WithAutoRun(false))
+				q3 := queues.NewQueue[iJob[string]]()
+				w3.queues.Register(q3, math.MaxInt)
+				q3.Enqueue(newJob("job", loadJobConfigs(w3.configs())))
+				w3.Start()
+				assert.Eventually(func() bool { return w3.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+				w3.Stop()
+				err = w3.Start()
+				assert.ErrorIs(err, ErrWorkerStopping, "Start() on stopping worker should return ErrWorkerStopping")
+
+				close(blockCh)
+				w2.Stop()
+				w2.WaitUntilStopped()
+				w3.WaitUntilStopped()
+			})
+
 			t.Run("restart functionality", func(t *testing.T) {
 				var jobsProcessed atomic.Uint32
 


### PR DESCRIPTION
## Summary

Comprehensive refactor and hardening of the worker's event-loop architecture, state machine, and public API. ~14 commits spanning context lifecycle rework, state-guard hardening, godoc audit, test modernization, and API consistency fixes.

## Changes

### Architecture
- **Move graceful shutdown into the event loop** — `ctx.Done()` handler lives inside `goEventLoop()`, eliminating the `goListenToContext()` goroutine (one per worker). Cleanup is now: status→stopping, `Wait()` for in-flight jobs, `removeAllWorkers()`, status→stopped, `Broadcast()`.
- **Always create a cancellable context** — `initContext()` guarantees every worker has a `context.WithCancel`, defaulting to `context.Background()` if the user provides none. `Configs.ctx` stores the parent for `Restart()`.
- **Remove `restarting` status** — `Restart()` simplified to `Stop() → WaitUntilStopped() → recreate ctx → Start()`. Removed `transitionToRestarting()`, `ErrWorkerRestarting`, the `restarting` status value, and `Status()`'s "Restarting" string.
- **Remove ticker management** — deleted `tickers []*time.Ticker` field, `stopTickers()`, `closeChannels()`. `goRemoveIdleWorkers()` now uses `select` on `ctx.Done()` instead of ranging over `ticker.C`, fixing goroutine leaks on restart.
- **Reuse channels across restarts** — `eventLoopSignal` and `errorChan` are created once in the constructor and never closed, making them safe for repeated `Restart()` calls.

### API Changes
- **Export `Start()`** — `start()` → public `Start()`. Added `WithAutoRun(false)` config option. Default is `true` (backward compatible). All tests updated.
- **`Resume()`** — now idempotent for already-active workers (returns `nil`). No longer starts from `initiated` (returns `ErrNotRunningWorker`). Simplified to single `CAS(paused, idle)` + `getStatusError()` fallback.
- **`Start()` state guard** — rejects `paused`/`pausing`/`stopping` (still have a running event-loop goroutine). Only accepts `initiated` or `stopped`. Prevents duplicate event-loop goroutines.
- **`WaitAndStop()` consistency fix** — removed internal `WaitUntilStopped()`. Now `WaitAndStop()` = `Wait()` (drain) + `Stop()` (non-blocking), matching the `WaitAndPause()` pattern. Use `StopAndWait()` when blocking is desired.
- **`Pause()` godoc** — now documents idempotency and all error returns.

### Bug Fixes
- **Prevent deadlock when context is cancelled with pending jobs** — event loop's `ctx.Done()` handler calls `Wait()` (waits for in-flight jobs) before cleanup.
- **Prevent deadlock in `Wait()` during pausing/stopping** — `Wait()` now treats `pausing`/`stopping` the same as `paused`/`stopped` (returns when `curProcessing == 0`).
- **Prevent tight error loop on empty queues** — `processNextJob()` returns `ErrGetNextQueue` directly (no `fmt.Errorf` wrapping). Event loop uses `switch { case errors.Is(err, ErrGetNextQueue): break }` to exit the inner for loop instead of sending errors to the error channel.
- **`processNextJob()` refactor** — `curProcessing.Add(1)` moved before dequeue. Added `undoProcessingIncrement()` helper that decrements, releases waiters, and notifies next-job pull. All error paths now properly call it (including `j.IsClosed()`, `parseToJob` failures, and `ErrFailedToCastJob`).
- **`initPoolNode()`** — `notifyToPullNextJobs()` only called when `processing < w.concurrency.Load()`, preventing spurious signals at capacity.
- **`sendError()` / `notifyToPullNextJobs()`** — removed `mx.RLock`/`RUnlock` wrappers (no longer needed since channels aren't closed during restart).
- **`WaitUntilIdle()` fix** — now also checks `curProcessing.Load() == 0` (previously only checked queue length, could return early while a job was mid-processing).
- **`freePoolNode()` refactor** — pool-keeping logic simplified: keep worker if queue is long, or under idle target, or idle expiry enabled; otherwise stop it.

### Dead Code Removed
- `restarting` status, `ErrWorkerRestarting`, `Status()` "Restarting" string
- `goListenToContext()`, `stopTickers()`, `closeChannels()`, `transitionToRestarting()`
- `tickers` field, `errInvalidStrategyType`, `WaitUntilFinished()` (deprecated)
- `fmt` import from worker.go
- `GetItemsLen()` from internal/queues
- `restarting` test cases from `TestIdempotentStateTransitions` and `TestStatusAllCases`

### Godoc Audit
All methods now have complete `Errors:` sections documenting every possible error:
- `Stop()` — idempotency docs, errors
- `Pause()` — idempotency docs, errors
- `Resume()` — idempotency docs, errors
- `Start()` — state constraints, errors
- `TunePool()` — `ErrSameConcurrency`, `getStatusError()` reference
- `Restart()` — concurrent restart guard, errors
- `StopAndWait()`, `WaitAndStop()`, `PauseAndWait()`, `WaitAndPause()` — cross-reference `Stop()`/`Pause()` docs

### Testing Improvements
- All `time.Sleep` polling replaced with channel-based synchronization (`started` chan) + `assert.Eventually`
- All `w.start()` calls removed (auto-start handles it) or replaced with explicit `WithAutoRun(false)` + manual `Start()`
- `assert.Eventually` replaces arbitrary `time.Sleep` for state transitions
- Added `WaitUntilStopped()` after async `Stop()` calls where tests query `IsStopped()` immediately
- Added concurrent safety tests: `TestStartConcurrency` (20 goroutines), `TestRestartConcurrency` (5 goroutines), `TestResumeConcurrency` (10 goroutines)
- Added `TestStart` subtest for `Start()` returning errors on `paused`/`pausing`/`stopping`
- `TestPublicWorkerErrors` — removed `strategy=99` hack, uses empty-queue `ErrAllItemsEmpty` path
- Event-loop processing-error test — uses `MockPersistentQueue.ShouldFailDequeue` instead of manual error injection
- Benchmark cleanup: `defer worker.StopAndWait()` (previously `WaitAndStop()`) for proper isolation
- `TestStopAndWaitErrorPath` — tests early return from `initiated` state
- `TestReleaseWaitersCleanup` — simplified to test event-loop cleanup via context cancellation
- `TestPausePausingFastPath` — tests direct `initiated ↔ paused` and `running → pausing → paused` transitions
- `TestRestartCoverage` — tests restart from `idle`, `paused`, and with user-provided context
- `TestWaitAndStop` — tests async behavior (no longer waits for `stopped`)
- `Makefile` — added `-timeout 5m` to `test` and `bench` targets

### Files Changed
```
Makefile                        |   4 +-
bench_test.go                   |  24 +-
config.go                       |  14 +
examples/context-worker/main.go |   2 +-
job_test.go                     |   2 -
persistent_test.go              |  17 +-
queue_manager.go                |   8 +-
queue_manager_test.go           |  17 +-
queue_test.go                   | 142 +++-------
waiters_test.go                 | 274 +++++++-----------
worker.go                       | 487 +++++++++++++++-----------------
worker_binder.go                |  20 +-
worker_binder_test.go           |  16 +-
worker_test.go                  | 595 ++++++++++++++++++----------------------
14 files changed, 685 insertions(+), 937 deletions(-)
```