### PR TITLE
docs/fix/feat/test: fix race conditions, export Start(), add WithAutoRun, and improve tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type ConfigFunc func(*configs)
 
 type configs struct {
 	concurrency              uint32
+	autoRun                  bool
 	strategy                 Strategy
 	minIdleWorkerRatio       uint8
 	jobIdGenerator           func() string
@@ -21,6 +22,7 @@ type configs struct {
 }
 
 var defaultConfig = configs{
+	autoRun:     true,
 	concurrency: 1,
 	jobIdGenerator: func() string {
 		return ""
@@ -204,6 +206,18 @@ func WithMinIdleWorkerRatio(percentage uint8) ConfigFunc {
 func WithConcurrency(concurrency int) ConfigFunc {
 	return func(c *configs) {
 		c.concurrency = withSafeConcurrency(concurrency)
+	}
+}
+
+// WithAutoRun configures whether the worker automatically starts when created.
+// When autoRun is true (the default), the worker begins processing immediately
+// after creation. When set to false, the worker remains in an initiated state
+// until Start() is called manually.
+//
+// Default: true
+func WithAutoRun(run bool) ConfigFunc {
+	return func(c *configs) {
+		c.autoRun = run
 	}
 }
 

--- a/job_test.go
+++ b/job_test.go
@@ -375,8 +375,6 @@ func TestJobCloseEdgeCases(t *testing.T) {
 		mockQueue := mocks.NewMockPersistentQueue()
 		worker := newWorker(workerFunc)
 		queue := newPersistentQueue(worker, mockQueue)
-
-		worker.start()
 		queue.Add("test")
 		worker.Wait()
 	})

--- a/persistent_test.go
+++ b/persistent_test.go
@@ -16,20 +16,17 @@ func setupPersistentQueue() (PersistentQueue[string], *worker[string, iJob[strin
 	}
 
 	mockQueue := mocks.NewMockPersistentQueue()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newPersistentQueue(worker, mockQueue)
 
 	return queue, worker, mockQueue
 }
 
 func setupPersistentPriorityQueue() (PersistentPriorityQueue[string], *worker[string, iJob[string]], *mocks.MockPersistentPriorityQueue) {
-	// Create a worker with a simple process function
-	workerFunc := func(j iJob[string]) {
-		// Simple processor that doesn't return anything
-	}
+	workerFunc := func(j iJob[string]) {}
 
 	mockQueue := mocks.NewMockPersistentPriorityQueue()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newPersistentPriorityQueue(worker, mockQueue)
 
 	return queue, worker, mockQueue
@@ -304,7 +301,7 @@ func TestPersistentQueueCapacity(t *testing.T) {
 	t.Run("Add returns false when at capacity", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		ok1 := queue.Add("item-1")
@@ -322,7 +319,7 @@ func TestPersistentQueueCapacity(t *testing.T) {
 	t.Run("IsFull returns correct state", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		assert.False(t, queue.IsFull(), "Empty queue should not be full")
@@ -339,7 +336,7 @@ func TestPersistentPriorityQueueCapacity(t *testing.T) {
 	t.Run("Add returns false when at capacity", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentPriorityQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentPriorityQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		ok1 := queue.Add("high", 1)
@@ -357,7 +354,7 @@ func TestPersistentPriorityQueueCapacity(t *testing.T) {
 	t.Run("IsFull returns correct state", func(t *testing.T) {
 		workerFunc := func(j iJob[string]) {}
 		mockQueue := mocks.NewMockPersistentPriorityQueue()
-		worker := newWorker(workerFunc)
+		worker := newWorker(workerFunc, WithAutoRun(false))
 		queue := newPersistentPriorityQueue(worker, mockQueue, WithQueueCapacity(2))
 
 		assert.False(t, queue.IsFull(), "Empty queue should not be full")

--- a/queue_test.go
+++ b/queue_test.go
@@ -18,7 +18,7 @@ func setupBasicQueue() (*queue[string], *worker[string, iJob[string]], *queues.Q
 	}
 
 	internalQueue := queues.NewQueue[any]()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -37,7 +37,7 @@ func setupResultQueue() (*resultQueue[string, int], *worker[string, iResultJob[s
 	}
 
 	internalQueue := queues.NewQueue[any]()
-	worker := newResultWorker(workerFunc)
+	worker := newResultWorker(workerFunc, WithAutoRun(false))
 	queue := newResultQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -53,7 +53,7 @@ func setupErrorQueue() (*errorQueue[string], *worker[string, iErrorJob[string]],
 	}
 
 	internalQueue := queues.NewQueue[any]()
-	worker := newErrWorker(workerFunc)
+	worker := newErrWorker(workerFunc, WithAutoRun(false))
 	queue := newErrorQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -62,13 +62,6 @@ func setupErrorQueue() (*errorQueue[string], *worker[string, iErrorJob[string]],
 // Test groups for each queue type
 func TestQueues(t *testing.T) {
 	t.Run("BasicQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupBasicQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue", func(t *testing.T) {
 			queue, _, internalQueue := setupBasicQueue()
 
@@ -83,7 +76,7 @@ func TestQueues(t *testing.T) {
 		t.Run("Processing job", func(t *testing.T) {
 			queue, worker, internalQueue := setupBasicQueue()
 
-			err := worker.start()
+			err := worker.Start()
 			assert.NoError(t, err, "Worker should start successfully")
 			defer worker.Stop()
 
@@ -110,7 +103,7 @@ func TestQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
+			err := worker.Start()
 			assert.NoError(t, err, "Worker should start successfully")
 			defer worker.Stop()
 
@@ -124,13 +117,6 @@ func TestQueues(t *testing.T) {
 	})
 
 	t.Run("ResultQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupResultQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue", func(t *testing.T) {
 			queue, _, internalQueue := setupResultQueue()
 
@@ -144,9 +130,7 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with result", func(t *testing.T) {
 			queue, worker, internalQueue := setupResultQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("42")
@@ -160,9 +144,7 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupResultQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("invalid")
@@ -189,8 +171,7 @@ func TestQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have five items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have five items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			results := groupJob.Results()
@@ -224,12 +205,6 @@ func TestQueues(t *testing.T) {
 	})
 
 	t.Run("ErrorQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupErrorQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
 
 		t.Run("Adding job to queue", func(t *testing.T) {
 			queue, _, internalQueue := setupErrorQueue()
@@ -244,13 +219,11 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with success", func(t *testing.T) {
 			queue, worker, internalQueue := setupErrorQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("success")
-			err = job.Err()
+			err := job.Err()
 
 			assert.NoError(t, err, "Job should complete without error")
 			assert.Equal(t, 0, queue.Len(), "Queue should have no pending jobs")
@@ -259,13 +232,11 @@ func TestQueues(t *testing.T) {
 
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupErrorQueue()
-
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("error")
-			err = job.Err()
+			err := job.Err()
 
 			assert.Error(t, err, "Job should return an error")
 			assert.Equal(t, "test error", err.Error(), "Error message should match expected")
@@ -286,8 +257,7 @@ func TestQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			errors := groupJob.Errs()
@@ -318,7 +288,7 @@ func setupPriorityQueue() (*priorityQueue[string], *worker[string, iJob[string]]
 	}
 
 	internalQueue := queues.NewPriorityQueue[any]()
-	worker := newWorker(workerFunc)
+	worker := newWorker(workerFunc, WithAutoRun(false))
 	queue := newPriorityQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -337,7 +307,7 @@ func setupResultPriorityQueue() (*resultPriorityQueue[string, int], *worker[stri
 	}
 
 	internalQueue := queues.NewPriorityQueue[any]()
-	worker := newResultWorker(workerFunc)
+	worker := newResultWorker(workerFunc, WithAutoRun(false))
 	queue := newResultPriorityQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -353,7 +323,7 @@ func setupErrorPriorityQueue() (*errorPriorityQueue[string], *worker[string, iEr
 	}
 
 	internalQueue := queues.NewPriorityQueue[any]()
-	worker := newErrWorker(workerFunc)
+	worker := newErrWorker(workerFunc, WithAutoRun(false))
 	queue := newErrorPriorityQueue(worker, internalQueue)
 
 	return queue, worker, internalQueue
@@ -362,13 +332,6 @@ func setupErrorPriorityQueue() (*errorPriorityQueue[string], *worker[string, iEr
 func TestPriorityQueues(t *testing.T) {
 	// Test cases for Priority Queue
 	t.Run("PriorityQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupPriorityQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue with priority", func(t *testing.T) {
 			queue, _, internalQueue := setupPriorityQueue()
 
@@ -389,8 +352,7 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing jobs with priority order", func(t *testing.T) {
 			queue, worker, _ := setupPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			// Add jobs with different priorities (lower number = higher priority)
@@ -421,8 +383,7 @@ func TestPriorityQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			// Wait for all jobs to complete
@@ -435,12 +396,6 @@ func TestPriorityQueues(t *testing.T) {
 	})
 
 	t.Run("ResultPriorityQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupResultPriorityQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
 
 		t.Run("Adding job to queue with priority", func(t *testing.T) {
 			queue, _, internalQueue := setupResultPriorityQueue()
@@ -463,8 +418,7 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing job with result and priority", func(t *testing.T) {
 			queue, worker, _ := setupResultPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			// Add jobs with different priorities (lower number = higher priority)
@@ -489,8 +443,7 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupResultPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("invalid", 1)
@@ -515,8 +468,7 @@ func TestPriorityQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			results := groupJob.Results()
@@ -538,13 +490,6 @@ func TestPriorityQueues(t *testing.T) {
 	})
 
 	t.Run("ErrorPriorityQueue", func(t *testing.T) {
-		t.Run("Start worker", func(t *testing.T) {
-			_, worker, _ := setupErrorPriorityQueue()
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
-			defer worker.Stop()
-		})
-
 		t.Run("Adding job to queue with priority", func(t *testing.T) {
 			queue, _, internalQueue := setupErrorPriorityQueue()
 
@@ -566,12 +511,11 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing successful job", func(t *testing.T) {
 			queue, worker, _ := setupErrorPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("success", 1)
-			err = job.Err()
+			err := job.Err()
 
 			assert.NoError(t, err, "Job should complete without error")
 		})
@@ -579,12 +523,11 @@ func TestPriorityQueues(t *testing.T) {
 		t.Run("Processing job with error", func(t *testing.T) {
 			queue, worker, _ := setupErrorPriorityQueue()
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			job, _ := queue.Add("error", 1)
-			err = job.Err()
+			err := job.Err()
 
 			assert.Error(t, err, "Job should return an error")
 			assert.Equal(t, "test error", err.Error(), "Error message should match expected")
@@ -605,8 +548,7 @@ func TestPriorityQueues(t *testing.T) {
 			assert.Equal(t, pending, internalQueue.Len(), "Internal Queue should have three items")
 			assert.Equal(t, pending, groupJob.NumPending(), "Group job should have three items")
 
-			err := worker.start()
-			assert.NoError(t, err, "Worker should start successfully")
+			worker.Start()
 			defer worker.Stop()
 
 			errors := groupJob.Errs()
@@ -677,9 +619,7 @@ func TestExternalQueue(t *testing.T) {
 		queue, worker, _ := setupBasicQueue()
 		assert := assert.New(t)
 
-		// Start the worker
-		err := worker.start()
-		assert.NoError(err, "Worker should start successfully")
+		worker.Start()
 
 		// Add several jobs
 		for i := range 5 {
@@ -688,7 +628,7 @@ func TestExternalQueue(t *testing.T) {
 		assert.LessOrEqual(queue.Len(), 5, "Queue should have at most five pending jobs")
 
 		// Close the queue
-		err = queue.Close()
+		err := queue.Close()
 		assert.NoError(err, "Close should not return an error")
 
 		_, ok := queue.Add("test-data-6")
@@ -704,7 +644,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("item-1")
@@ -739,7 +679,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Zero capacity means unlimited", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(0))
 
 			for i := range 100 {
@@ -762,7 +702,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("IsFull returns correct state", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			assert.False(t, queue.IsFull(), "Empty queue should not be full")
@@ -788,7 +728,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("high", 1)
@@ -806,7 +746,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newWorker(workerFunc)
+			worker := newWorker(workerFunc, WithAutoRun(false))
 			queue := newPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -824,7 +764,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("item-1")
@@ -842,7 +782,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -861,7 +801,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("item-1")
@@ -879,7 +819,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -898,7 +838,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("high", 1)
@@ -916,7 +856,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iResultJob[string, int]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newResultWorker(workerFunc)
+			worker := newResultWorker(workerFunc, WithAutoRun(false))
 			queue := newResultPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{
@@ -934,7 +874,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("Add returns false when at capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			_, ok1 := queue.Add("high", 1)
@@ -952,7 +892,7 @@ func TestQueueCapacity(t *testing.T) {
 		t.Run("AddAll skips items beyond capacity", func(t *testing.T) {
 			workerFunc := func(j iErrorJob[string]) {}
 			internalQueue := queues.NewPriorityQueue[any]()
-			worker := newErrWorker(workerFunc)
+			worker := newErrWorker(workerFunc, WithAutoRun(false))
 			queue := newErrorPriorityQueue(worker, internalQueue, WithQueueCapacity(2))
 
 			items := []Item[string]{

--- a/waiters_test.go
+++ b/waiters_test.go
@@ -1,6 +1,7 @@
 package varmq
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,8 +17,6 @@ func TestWaiters(t *testing.T) {
 	t.Run("Wait", func(t *testing.T) {
 		t.Run("returns immediately when idle with no work", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			err := w.start()
-			assert.NoError(t, err)
 			defer w.Stop()
 
 			done := make(chan struct{})
@@ -54,7 +53,9 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("waits for queue to drain", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{}, 2)
 			w := newWorker(func(j iJob[string]) {
+				started <- struct{}{}
 				<-blockCh
 			})
 			assert := assert.New(t)
@@ -62,23 +63,19 @@ func TestWaiters(t *testing.T) {
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
 
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
-			// Add jobs to queue
 			for i := range 2 {
 				q.Enqueue(newJob("job-"+string(rune(i)), loadJobConfigs(w.configs())))
 			}
 			w.notifyToPullNextJobs()
 
-			// Wait for at least one job to be in-flight
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Greater(w.NumProcessing(), 0, "At least one job should be in-flight")
 
 			done := make(chan struct{})
@@ -120,8 +117,6 @@ func TestWaiters(t *testing.T) {
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
 
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
 			// Enqueue a job that will block
@@ -131,18 +126,10 @@ func TestWaiters(t *testing.T) {
 			// Wait for job to start
 			select {
 			case <-started:
-				// Job has started
 			case <-time.After(500 * time.Millisecond):
 				t.Fatal("Job should have started")
 			}
 
-			// Poll until NumProcessing > 0 (for -race resilience)
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
-			}
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -174,12 +161,8 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns when paused with no in-flight jobs", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Pause with no work
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -202,20 +185,16 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns when stopped with no in-flight jobs", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
+			err := w.Stop()
 			assert.NoError(err)
+			w.WaitUntilStopped()
+			assert.True(w.IsStopped(), "Worker should be stopped")
 
-		err = w.Stop()
-		assert.NoError(err)
-		w.WaitUntilStopped()
-		assert.True(w.IsStopped(), "Worker should be stopped")
-
-		done := make(chan struct{})
-		go func() {
-			w.Wait()
-			close(done)
-		}()
+			done := make(chan struct{})
+			go func() {
+				w.Wait()
+				close(done)
+			}()
 
 			select {
 			case <-done:
@@ -236,10 +215,6 @@ func TestWaiters(t *testing.T) {
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Start a job that blocks
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
@@ -247,24 +222,16 @@ func TestWaiters(t *testing.T) {
 			// Wait for job to start
 			select {
 			case <-started:
-				// Job started
 			case <-time.After(500 * time.Millisecond):
 				t.Fatal("Job should have started")
 			}
 
-			// Poll until NumProcessing > 0 (for -race resilience)
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
-			}
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			// Pause while job is in-flight -> transitions to Pausing
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
-			assert.Equal(pausing, w.status.Load(), "Status should be Pausing")
+			assert.Equal(pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 			done := make(chan struct{})
 			go func() {
@@ -298,8 +265,6 @@ func TestWaiters(t *testing.T) {
 	t.Run("WaitUntilIdle", func(t *testing.T) {
 		t.Run("returns immediately when already idle", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			err := w.start()
-			assert.NoError(t, err)
 			defer w.Stop()
 
 			done := make(chan struct{})
@@ -328,8 +293,6 @@ func TestWaiters(t *testing.T) {
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
 
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
 			// Add a job that will cause Running status
@@ -374,11 +337,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("blocks when paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -388,13 +347,14 @@ func TestWaiters(t *testing.T) {
 				close(done)
 			}()
 
-			// Should block because Paused != Idle
 			select {
 			case <-done:
 				t.Fatal("WaitUntilIdle() should block when worker is Paused")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Resume()
+			<-done
 
 			w.Stop()
 		})
@@ -402,28 +362,27 @@ func TestWaiters(t *testing.T) {
 		t.Run("blocks when stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
+			err := w.Stop()
 			assert.NoError(err)
+			w.WaitUntilStopped()
+			assert.True(w.IsStopped(), "Worker should be stopped")
 
-		err = w.Stop()
-		assert.NoError(err)
-		w.WaitUntilStopped()
-		assert.True(w.IsStopped(), "Worker should be stopped")
+			done := make(chan struct{})
+			go func() {
+				w.WaitUntilIdle()
+				close(done)
+			}()
 
-		done := make(chan struct{})
-		go func() {
-			w.WaitUntilIdle()
-			close(done)
-		}()
-
-			// Should block because Stopped != Idle
 			select {
 			case <-done:
 				t.Fatal("WaitUntilIdle() should block when worker is Stopped")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Restart()
+			<-done
+
+			w.Stop()
 		})
 	})
 
@@ -431,11 +390,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns immediately when already paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -457,34 +412,30 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("waits for pausing to paused transition", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 			})
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
 
-			// Wait for job to start (polling loop for -race resilience)
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			// Pause -> transitions to Pausing
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
-			assert.Equal(pausing, w.status.Load(), "Status should be Pausing")
+			assert.Equal(pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 			done := make(chan struct{})
 			go func() {
@@ -515,11 +466,6 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("blocks when never paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-			defer w.Stop()
 
 			done := make(chan struct{})
 			go func() {
@@ -527,13 +473,16 @@ func TestWaiters(t *testing.T) {
 				close(done)
 			}()
 
-			// Worker is Idle, never paused - should block indefinitely
 			select {
 			case <-done:
 				t.Fatal("WaitUntilPaused() should block when worker is never paused")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Pause()
+			<-done
+
+			w.Stop()
 		})
 	})
 
@@ -541,20 +490,16 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns immediately when already stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
+			err := w.Stop()
 			assert.NoError(err)
-
-		err = w.Stop()
-		assert.NoError(err)
-		w.WaitUntilStopped()
-		assert.True(w.IsStopped(), "Worker should be stopped")
-
-		done := make(chan struct{})
-		go func() {
 			w.WaitUntilStopped()
-			close(done)
-		}()
+			assert.True(w.IsStopped(), "Worker should be stopped")
+
+			done := make(chan struct{})
+			go func() {
+				w.WaitUntilStopped()
+				close(done)
+			}()
 
 			select {
 			case <-done:
@@ -566,25 +511,28 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("waits for stopping to stopped transition", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 			})
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
-			time.Sleep(20 * time.Millisecond)
+
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
+			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			// Stop -> transitions to Stopping
-			err = w.Stop()
+			err := w.Stop()
 			assert.NoError(err)
 			assert.Equal(stopping, w.status.Load(), "Status should be Stopping")
 
@@ -615,10 +563,6 @@ func TestWaiters(t *testing.T) {
 
 		t.Run("blocks when never stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
-			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
 			defer w.Stop()
 
 			done := make(chan struct{})
@@ -651,21 +595,16 @@ func TestWaiters(t *testing.T) {
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
 
-			// Wait for job to start
-			for i := 0; i < 200; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -701,11 +640,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("with no jobs returns immediately paused", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.PauseAndWait()
+			err := w.PauseAndWait()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused immediately")
 
@@ -713,8 +648,7 @@ func TestWaiters(t *testing.T) {
 		})
 
 		t.Run("returns error when not running", func(t *testing.T) {
-			w := newWorker(func(j iJob[string]) {})
-			// Never started
+			w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 
 			err := w.PauseAndWait()
 			assert.ErrorIs(t, err, ErrNotRunningWorker)
@@ -724,19 +658,17 @@ func TestWaiters(t *testing.T) {
 	t.Run("WaitAndPause", func(t *testing.T) {
 		t.Run("waits for work then pauses", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {
-				time.Sleep(30 * time.Millisecond)
-			})
+				time.Sleep(500 * time.Millisecond)
+			}, WithAutoRun(false))
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Add a job
 			q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
+
+			w.Start()
+			defer w.Stop()
 
 			done := make(chan struct{})
 			go func() {
@@ -745,34 +677,26 @@ func TestWaiters(t *testing.T) {
 				close(done)
 			}()
 
-			// Should block while job is processing
 			select {
 			case <-done:
 				t.Fatal("WaitAndPause() should block while work is in progress")
-			case <-time.After(20 * time.Millisecond):
-				// Expected
+			case <-time.After(200 * time.Millisecond):
 			}
 
-			// Wait for job to complete and pause
 			select {
 			case <-done:
 				assert.True(w.IsPaused(), "Worker should be Paused")
 				assert.Equal(0, w.NumPending(), "Queue should be empty")
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(2 * time.Second):
 				t.Fatal("WaitAndPause() should return after work completes")
 			}
 
-			w.Stop()
 		})
 
 		t.Run("returns immediately when no work", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.WaitAndPause()
+			err := w.WaitAndPause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
@@ -783,23 +707,26 @@ func TestWaiters(t *testing.T) {
 	t.Run("StopAndWait", func(t *testing.T) {
 		t.Run("with in-flight jobs blocks until stopped", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			var processed bool
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 				processed = true
-			})
+			}, WithAutoRun(false))
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Start a blocking job
 			q.Enqueue(newJob("block", loadJobConfigs(w.configs())))
-			w.notifyToPullNextJobs()
-			time.Sleep(20 * time.Millisecond)
+			w.Start()
+
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
+			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -835,11 +762,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("with no jobs returns immediately stopped", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.StopAndWait()
+			err := w.StopAndWait()
 			assert.NoError(err)
 			assert.True(w.IsStopped(), "Worker should be stopped immediately")
 		})
@@ -848,28 +771,24 @@ func TestWaiters(t *testing.T) {
 	t.Run("WaitAndStop", func(t *testing.T) {
 		t.Run("waits for work then stops", func(t *testing.T) {
 			blockCh := make(chan struct{})
+			started := make(chan struct{})
 			w := newWorker(func(j iJob[string]) {
+				close(started)
 				<-blockCh
 			})
 			assert := assert.New(t)
 
 			q := queues.NewQueue[iJob[string]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Add a blocking job
 			q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
 			w.notifyToPullNextJobs()
 
-			// Wait for job to start
-			for i := 0; i < 100; i++ {
-				if w.NumProcessing() > 0 {
-					break
-				}
-				time.Sleep(5 * time.Millisecond)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("Job should have started")
 			}
+
 			assert.Equal(1, w.NumProcessing(), "Job should be in-flight")
 
 			done := make(chan struct{})
@@ -905,11 +824,7 @@ func TestWaiters(t *testing.T) {
 		t.Run("returns immediately when no work", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			err = w.WaitAndStop()
+			err := w.WaitAndStop()
 			assert.NoError(err)
 			assert.True(w.IsStopped(), "Worker should be stopped")
 		})
@@ -919,16 +834,10 @@ func TestWaiters(t *testing.T) {
 		t.Run("Wait returns when paused, WaitUntilIdle blocks", func(t *testing.T) {
 			w := newWorker(func(j iJob[string]) {})
 			assert := assert.New(t)
-
-			err := w.start()
-			assert.NoError(err)
-
-			// Pause with no work -> status is Paused immediately
-			err = w.Pause()
+			err := w.Pause()
 			assert.NoError(err)
 			assert.True(w.IsPaused(), "Worker should be paused")
 
-			// Wait() should return because no work and no processing
 			doneWait := make(chan struct{})
 			go func() {
 				w.Wait()
@@ -937,12 +846,10 @@ func TestWaiters(t *testing.T) {
 
 			select {
 			case <-doneWait:
-				// Success - Wait returns when paused with no work
 			case <-time.After(100 * time.Millisecond):
 				t.Fatal("Wait() should return when paused with no work")
 			}
 
-			// WaitUntilIdle() should block because status is Paused, not Idle
 			doneIdle := make(chan struct{})
 			go func() {
 				w.WaitUntilIdle()
@@ -953,8 +860,10 @@ func TestWaiters(t *testing.T) {
 			case <-doneIdle:
 				t.Fatal("WaitUntilIdle() should block when status is Paused")
 			case <-time.After(100 * time.Millisecond):
-				// Expected - still blocked
 			}
+
+			w.Resume()
+			<-doneIdle
 
 			w.Stop()
 		})
@@ -975,10 +884,6 @@ func TestWaiters(t *testing.T) {
 
 			q := queues.NewQueue[iJob[int]]()
 			w.queues.Register(q, 1)
-
-			err := w.start()
-			assert.NoError(err)
-
 			// Start some jobs
 			for i := range 3 {
 				q.Enqueue(newJob(i, loadJobConfigs(w.configs())))
@@ -1016,7 +921,7 @@ func TestWaiters(t *testing.T) {
 			select {
 			case <-done:
 				assert.True(w.IsActive(), "Worker should be active after restart")
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(2 * time.Second):
 				t.Fatal("Restart() should return after in-flight jobs complete")
 			}
 

--- a/worker.go
+++ b/worker.go
@@ -422,7 +422,7 @@ func (w *worker[T, JobType]) WaitUntilIdle() {
 	defer w.mx.Unlock()
 
 	for {
-		if w.status.Load() == idle && w.queues.Len() == 0 {
+		if w.status.Load() == idle && w.queues.Len() == 0 && w.curProcessing.Load() == 0 {
 			return
 		}
 
@@ -452,6 +452,14 @@ func (w *worker[T, JobType]) Errs() <-chan error {
 	return w.errorChan
 }
 
+func (w *worker[T, JobType]) undoProcessingIncrement() {
+	processing := w.curProcessing.Add(^uint32(0))
+	w.releaseWaiters(processing)
+	if processing < w.concurrency.Load() {
+		w.notifyToPullNextJobs()
+	}
+}
+
 // processNextJob processes the next Job in the queue.
 func (w *worker[T, JobType]) processNextJob() error {
 	queue, err := w.queues.next()
@@ -459,6 +467,9 @@ func (w *worker[T, JobType]) processNextJob() error {
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrGetNextQueue, err)
 	}
+
+	w.curProcessing.Add(1)
+	w.status.CompareAndSwap(idle, running)
 
 	var (
 		v     any
@@ -474,42 +485,41 @@ func (w *worker[T, JobType]) processNextJob() error {
 	}
 
 	if !ok {
+		w.undoProcessingIncrement()
 		return ErrFailedToDequeue
 	}
 
 	var j JobType
 
-	// check the type of the value
-	// and cast it to the appropriate job type
 	switch value := v.(type) {
 	case JobType:
 		j = value
 	case []byte:
 		var err error
 		if v, err = parseToJob[T](value); err != nil {
+			w.undoProcessingIncrement()
 			return err
 		}
 
 		if j, ok = v.(JobType); !ok {
+			w.undoProcessingIncrement()
 			return ErrFailedToCastJob
 		}
 
 		j.setInternalQueue(queue)
 	default:
+		w.undoProcessingIncrement()
 		return ErrFailedToCastJob
 	}
 
 	if j.IsClosed() {
+		w.undoProcessingIncrement()
 		return nil
 	}
 
-	w.curProcessing.Add(1)
 	j.changeStatus(processing)
 	j.setAckId(ackId)
-	// if worker is idle, change the status to running
-	w.status.CompareAndSwap(idle, running)
 
-	// then job will be process by the processSingleJob function inside spawnWorker
 	w.sendToNextChannel(j)
 
 	return nil
@@ -726,12 +736,15 @@ func (w *worker[T, JobType]) Pause() error {
 	}
 
 	if w.status.CompareAndSwap(idle, paused) {
+		// won't Broadcast from releaseWaiters
+		w.waiters.Broadcast()
 		return nil
 	}
 
 	if w.status.CompareAndSwap(running, pausing) {
-		if w.NumProcessing() == 0 {
-			w.status.CompareAndSwap(pausing, paused)
+		if w.NumProcessing() == 0 && w.status.CompareAndSwap(pausing, paused) {
+			// won't Broadcast from releaseWaiters
+			w.waiters.Broadcast()
 		}
 		return nil
 	}
@@ -741,6 +754,7 @@ func (w *worker[T, JobType]) Pause() error {
 
 func (w *worker[T, JobType]) Resume() error {
 	if w.status.CompareAndSwap(paused, idle) {
+		w.waiters.Broadcast()
 		w.notifyToPullNextJobs()
 		return nil
 	}
@@ -782,7 +796,9 @@ func (w *worker[T, JobType]) Stop() error {
 
 	for _, from := range []status{running, idle, pausing, paused} {
 		if w.status.CompareAndSwap(from, stopping) {
+			w.mx.Lock()
 			w.cancel()
+			w.mx.Unlock()
 			return nil
 		}
 	}

--- a/worker.go
+++ b/worker.go
@@ -298,6 +298,10 @@ func newWorker[T any](wf func(j iJob[T]), configs ...any) *worker[T, iJob[T]] {
 	w.concurrency.Store(c.concurrency)
 	w.initContext(c.ctx)
 
+	if c.autoRun {
+		w.Start()
+	}
+
 	return w
 }
 
@@ -319,6 +323,10 @@ func newErrWorker[T any](wf func(j iErrorJob[T]), configs ...any) *worker[T, iEr
 	w.concurrency.Store(c.concurrency)
 	w.initContext(c.ctx)
 
+	if c.autoRun {
+		w.Start()
+	}
+
 	return w
 }
 
@@ -339,6 +347,10 @@ func newResultWorker[T, R any](wf func(j iResultJob[T, R]), configs ...any) *wor
 	w.waiters = sync.NewCond(&w.mx)
 	w.concurrency.Store(c.concurrency)
 	w.initContext(c.ctx)
+
+	if c.autoRun {
+		w.Start()
+	}
 
 	return w
 }
@@ -766,7 +778,7 @@ func (w *worker[T, JobType]) Resume() error {
 	return w.getStatusError()
 }
 
-func (w *worker[T, JobType]) start() error {
+func (w *worker[T, JobType]) Start() error {
 	w.mx.Lock()
 	defer w.mx.Unlock()
 

--- a/worker.go
+++ b/worker.go
@@ -811,25 +811,20 @@ func (w *worker[T, JobType]) Restart() error {
 		return err
 	}
 
-	// Wait for the worker to reach a terminal state (stopped or active).
-	// If another goroutine already restarted this worker while we were
-	// waiting, IsActive() will be true and we return ErrRunningWorker.
-	// sync.Cond.Wait() atomically releases w.mx and re-acquires it on wake-up.
 	w.mx.Lock()
 	for !w.IsStopped() && !w.IsActive() {
 		w.waiters.Wait()
 	}
+
 	if w.IsActive() {
 		w.mx.Unlock()
 		return ErrRunningWorker
 	}
 
-	// Create a new context before releasing the lock so that start()
-	// and the event loop goroutine see the updated context.
 	w.ctx, w.cancel = context.WithCancel(w.Configs.ctx)
 	w.mx.Unlock()
 
-	return w.start()
+	return w.Start()
 }
 
 func (w *worker[T, JobType]) IsPaused() bool {

--- a/worker.go
+++ b/worker.go
@@ -131,6 +131,14 @@ type Worker interface {
 	//
 	// Once Paused, no new jobs are processed from the queue. Use Resume()
 	// to resume processing, or PauseAndWait() to block until fully paused.
+	//
+	// Pause is idempotent: calling Pause on an already Paused or Pausing
+	// worker returns nil.
+	//
+	// Errors:
+	//   - ErrWorkerStopped: worker is in the Stopped state.
+	//   - ErrWorkerStopping: worker is in the Stopping state.
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
 	Pause() error
 
 	// Stop initiates a graceful shutdown of the worker.
@@ -142,15 +150,51 @@ type Worker interface {
 	//
 	// A stopped worker cannot be resumed; use Restart() instead.
 	// Use StopAndWait() to block until fully stopped.
+	//
+	// Stop is idempotent: calling Stop on an already Stopped or Stopping
+	// worker returns nil.
+	//
+	// Errors:
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
+	//   - ErrWorkerStopped: worker is already in the Stopped state
+	//     (returned when called from an invalid intermediate state; the
+	//     idempotent path above returns nil for Stopped/Stopping).
 	Stop() error
 	// Restart gracefully restarts the worker, preserving any pending
 	// jobs in the queue. It stops the worker, waits for it to reach
 	// Stopped, recreates the internal context, and starts again.
+	//
+	// Restart works from any valid state: Running, Idle, Pausing, Paused,
+	// Stopping, or Stopped. It transparently handles the case where another
+	// goroutine already restarted the worker by returning ErrRunningWorker.
+	//
+	// Errors:
+	//   - ErrRunningWorker: worker is already active (concurrent restart).
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
+	//   - Errors from Stop(): see Stop's error documentation.
 	Restart() error
 	// Resume resumes a paused worker and begins processing pending
-	// jobs from the queue. This has no effect on a stopped worker —
-	// use Restart() instead.
+	// jobs from the queue.
+	//
+	// Resume is idempotent: calling Resume on an already active (Running or
+	// Idle) worker returns nil.
+	//
+	// Errors:
+	//   - ErrWorkerStopped: worker is in the Stopped state. Use Restart().
+	//   - ErrWorkerStopping: worker is in the Stopping state.
+	//   - ErrNotRunningWorker: worker is in the Initiated state.
 	Resume() error
+	// Start begins processing jobs from the bound queues.
+	// When WithAutoRun is true (the default), the worker starts automatically
+	// after creation and this method returns ErrRunningWorker.
+	// Use WithAutoRun(false) to create a worker in an initiated state,
+	// then call Start() manually when ready.
+	//
+	// Errors:
+	//   - ErrRunningWorker: worker is already active (Running or Idle).
+	//   - ErrNotRunningWorker: worker is in an unexpected state
+	//     (not Initiated or any other valid start state).
+	Start() error
 	// WaitUntilFinished waits until all pending jobs are processed and the worker
 	// has no in-flight work. This is an alias for Wait().
 	//

--- a/worker_binder.go
+++ b/worker_binder.go
@@ -178,10 +178,8 @@ func (wb *workerBinder[T]) BindQueue(configs ...QueueConfigFunc) Queue[T] {
 }
 
 // WithQueue binds an existing queue implementation to the worker
-// It starts the worker and returns a Queue interface to interact with the queue
+// It returns a Queue interface to interact with the queue
 func (wb *workerBinder[T]) WithQueue(q IQueue, configs ...QueueConfigFunc) Queue[T] {
-	defer wb.start()
-
 	return newQueue(wb.worker, q, configs...)
 }
 
@@ -190,27 +188,20 @@ func (wb *workerBinder[T]) BindPriorityQueue(configs ...QueueConfigFunc) Priorit
 }
 
 func (wb *workerBinder[T]) WithPriorityQueue(pq IPriorityQueue, configs ...QueueConfigFunc) PriorityQueue[T] {
-	defer wb.start()
-
 	return newPriorityQueue(wb.worker, pq, configs...)
 }
 
 func (wb *workerBinder[T]) WithPersistentQueue(pq IPersistentQueue, configs ...QueueConfigFunc) PersistentQueue[T] {
-	defer wb.start()
-
 	return newPersistentQueue(wb.worker, pq, configs...)
 }
 
 func (wb *workerBinder[T]) WithPersistentPriorityQueue(pq IPersistentPriorityQueue, configs ...QueueConfigFunc) PersistentPriorityQueue[T] {
-	defer wb.start()
-
 	return newPersistentPriorityQueue(wb.worker, pq, configs...)
 }
 
 func (wb *workerBinder[T]) WithDistributedQueue(dq IDistributedQueue, configs ...QueueConfigFunc) DistributedQueue[T] {
 	c := loadQueueConfigs(configs...)
 	defer dq.Subscribe(wb.handleQueueSubscription)
-	defer wb.start()
 	defer wb.queues.Register(dq, c.priority)
 
 	return NewDistributedQueue[T](dq, configs...)
@@ -219,7 +210,6 @@ func (wb *workerBinder[T]) WithDistributedQueue(dq IDistributedQueue, configs ..
 func (wb *workerBinder[T]) WithDistributedPriorityQueue(dpq IDistributedPriorityQueue, configs ...QueueConfigFunc) DistributedPriorityQueue[T] {
 	c := loadQueueConfigs(configs...)
 	defer dpq.Subscribe(wb.handleQueueSubscription)
-	defer wb.start()
 	defer wb.queues.Register(dpq, c.priority)
 
 	return NewDistributedPriorityQueue[T](dpq, configs...)
@@ -308,8 +298,6 @@ func (ewb *errWorkerBinder[T]) BindQueue(configs ...QueueConfigFunc) ErrQueue[T]
 }
 
 func (ewb *errWorkerBinder[T]) WithQueue(q IQueue, configs ...QueueConfigFunc) ErrQueue[T] {
-	defer ewb.worker.start()
-
 	return newErrorQueue(ewb.worker, q, configs...)
 }
 
@@ -318,8 +306,6 @@ func (ewb *errWorkerBinder[T]) BindPriorityQueue(configs ...QueueConfigFunc) Err
 }
 
 func (ewb *errWorkerBinder[T]) WithPriorityQueue(pq IPriorityQueue, configs ...QueueConfigFunc) ErrPriorityQueue[T] {
-	defer ewb.worker.start()
-
 	return newErrorPriorityQueue(ewb.worker, pq, configs...)
 }
 
@@ -410,8 +396,6 @@ func (rwb *resultWorkerBinder[T, R]) BindQueue(configs ...QueueConfigFunc) Resul
 }
 
 func (rwb *resultWorkerBinder[T, R]) WithQueue(q IQueue, configs ...QueueConfigFunc) ResultQueue[T, R] {
-	defer rwb.worker.start()
-
 	return newResultQueue(rwb.worker, q, configs...)
 }
 
@@ -420,7 +404,5 @@ func (rwb *resultWorkerBinder[T, R]) BindPriorityQueue(configs ...QueueConfigFun
 }
 
 func (rwb *resultWorkerBinder[T, R]) WithPriorityQueue(pq IPriorityQueue, configs ...QueueConfigFunc) ResultPriorityQueue[T, R] {
-	defer rwb.worker.start()
-
 	return newResultPriorityQueue(rwb.worker, pq, configs...)
 }

--- a/worker_binder_test.go
+++ b/worker_binder_test.go
@@ -132,10 +132,6 @@ func TestHandleQueueSubscription(t *testing.T) {
 		// Get the worker binder to access handleQueueSubscription
 		binder := worker.(*workerBinder[string])
 
-		// Start the worker so it can process notifications
-		err := binder.worker.start()
-		assert.NoError(t, err, "Worker should start successfully")
-
 		// Test handleQueueSubscription directly
 		// This simulates what happens when a distributed queue notifies about an enqueued job
 		binder.handleQueueSubscription("enqueued")
@@ -335,6 +331,7 @@ func TestWorkerBinders(t *testing.T) {
 	t.Run("HasDistributedQueueMethod", func(t *testing.T) {
 		// Create a worker
 		w := newWorker(func(j iJob[string]) {})
+		defer w.Stop()
 
 		// Create a worker binder
 		binder := newQueues(w)
@@ -346,13 +343,12 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithDistributedPriorityQueue")
 		assert.True(t, exists, "WorkerBinder should have WithDistributedPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	t.Run("HasPersistentQueueMethod", func(t *testing.T) {
 		// Create a worker
 		w := newWorker(func(j iJob[string]) {})
+		defer w.Stop()
 
 		// Create a worker binder
 		binder := newQueues(w)
@@ -364,8 +360,6 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithPersistentPriorityQueue")
 		assert.True(t, exists, "WorkerBinder should have WithPersistentPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	t.Run("ResultHasQueueMethods", func(t *testing.T) {
@@ -373,6 +367,7 @@ func TestWorkerBinders(t *testing.T) {
 		w := newResultWorker(func(j iResultJob[string, int]) {
 			j.sendResult(len(j.Data()))
 		})
+		defer w.Stop()
 
 		// Create a result worker binder
 		binder := newResultQueues(w)
@@ -393,8 +388,6 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithPriorityQueue")
 		assert.True(t, exists, "ResultWorkerBinder should have WithPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	t.Run("ErrHasQueueMethods", func(t *testing.T) {
@@ -402,6 +395,7 @@ func TestWorkerBinders(t *testing.T) {
 		w := newErrWorker(func(j iErrorJob[string]) {
 			j.sendError(nil)
 		})
+		defer w.Stop()
 
 		// Create an error worker binder
 		binder := newErrQueues(w)
@@ -422,8 +416,6 @@ func TestWorkerBinders(t *testing.T) {
 
 		_, exists = binderType.MethodByName("WithPriorityQueue")
 		assert.True(t, exists, "ErrWorkerBinder should have WithPriorityQueue method")
-
-		// No need to clean up as worker wasn't started
 	})
 
 	// Test result worker binder

--- a/worker_test.go
+++ b/worker_test.go
@@ -3,6 +3,7 @@ package varmq
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"reflect"
 	"strconv"
@@ -24,10 +25,9 @@ func TestWorkers(t *testing.T) {
 		// Group 1: Initialization tests
 		t.Run("Initialization", func(t *testing.T) {
 			t.Run("with default configuration", func(t *testing.T) {
-				// Create worker with default config
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 				assert := assert.New(t)
 
 				// Validate worker structure
@@ -124,14 +124,12 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, initialConcurrency, w.NumConcurrency(), "CurrentConcurrency should match initial value")
 
 				newConcurrency := 5
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(t, err, "TunePool should not return error")
 
 				assert.Equal(t, newConcurrency, w.NumConcurrency(), "CurrentConcurrency should return updated value after tuning")
@@ -143,7 +141,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("worker not running error", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				}, WithConcurrency(2))
+				}, WithConcurrency(2), WithAutoRun(false))
 				err := w.TunePool(4)
 				assert.Error(t, err, "TunePool should return error when worker is not running")
 				assert.Equal(t, ErrNotRunningWorker, err, "Should return specific 'worker not running' error")
@@ -154,14 +152,12 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, uint32(initialConcurrency), w.concurrency.Load(), "Initial concurrency should be set correctly")
 
 				newConcurrency := 5
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 
 				assert.Equal(t, newConcurrency, w.NumConcurrency(), "Concurrency should be updated to new value")
@@ -174,14 +170,12 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, uint32(initialConcurrency), w.concurrency.Load(), "Initial concurrency should be set correctly")
 
 				newConcurrency := 2
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 
 				assert.Equal(t, newConcurrency, w.NumConcurrency(), "Concurrency should be updated to new lower value")
@@ -194,11 +188,9 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
-				err = w.TunePool(0)
+				err := w.TunePool(0)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 				assert.Equal(t, withSafeConcurrency(0), w.concurrency.Load(), "Should use minimum safe concurrency when 0 is provided")
 			})
@@ -208,11 +200,9 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
-				err = w.TunePool(-5)
+				err := w.TunePool(-5)
 				assert.NoError(t, err, "TunePool should not return error on running worker")
 				assert.Equal(t, withSafeConcurrency(-5), w.concurrency.Load(), "Should use minimum safe concurrency when negative value is provided")
 			})
@@ -222,12 +212,10 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithConcurrency(initialConcurrency))
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				assert.Equal(t, uint32(initialConcurrency), w.concurrency.Load(), "Initial concurrency should be set correctly")
-				err = w.TunePool(initialConcurrency)
+				err := w.TunePool(initialConcurrency)
 				assert.ErrorIs(t, err, ErrSameConcurrency, "TunePool should return error when concurrency is the same")
 				assert.Equal(t, initialConcurrency, w.NumConcurrency(), "Concurrency should remain unchanged when set to same value")
 			})
@@ -241,6 +229,7 @@ func TestWorkers(t *testing.T) {
 				},
 					WithConcurrency(initialConcurrency),
 					WithIdleWorkerExpiryDuration(idleExpiryDuration),
+					WithAutoRun(false),
 				)
 
 				// Create a queue for testing
@@ -259,18 +248,18 @@ func TestWorkers(t *testing.T) {
 					q.Enqueue(newJob("job"+string(rune(i)), loadJobConfigs(w.configs())))
 				}
 
-			err := w.start()
-			assert := assert.New(t)
-			assert.NoError(err, "Worker should start without error")
+				assert := assert.New(t)
 
-			// Wait for jobs to be processed and pool to expand
-			w.Wait()
+				w.Start()
+
+				// Wait for jobs to be processed and pool to expand
+				w.Wait()
 
 				assert.Equal(w.pool.Len(), w.NumConcurrency(), "Pool size should be equal to the concurrency")
 
 				// Decrease concurrency
 				newConcurrency := 3
-				err = w.TunePool(newConcurrency)
+				err := w.TunePool(newConcurrency)
 				assert.NoError(err, "TunePool should not return error when decreasing concurrency")
 
 				// Concurrency should be updated but pool size should not be manually shrunk
@@ -278,9 +267,8 @@ func TestWorkers(t *testing.T) {
 					"Concurrency should be updated to new lower value")
 
 				assert.Greater(w.pool.Len(), newConcurrency, "Pool size should be greater than the concurrency")
-				time.Sleep(idleExpiryDuration * 2)
-				// After the expiration the pool size must be equal to one
-				assert.Equal(w.pool.Len(), 1, "Pool size should be equal to one after expiration")
+
+				assert.Eventually(func() bool { return w.pool.Len() == 1 }, idleExpiryDuration*4, 10*time.Millisecond, "Pool size should be equal to one after expiration")
 			})
 
 		})
@@ -290,7 +278,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("worker state transitions", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 				assert := assert.New(t)
 
 				assert.Equal(initiated, w.status.Load(), "Initial status should be 'initiated'")
@@ -299,13 +287,13 @@ func TestWorkers(t *testing.T) {
 				assert.False(w.IsPaused(), "Worker should not be paused initially")
 				assert.False(w.IsStopped(), "Worker should not be stopped initially")
 
-				err := w.start()
+				err := w.Start()
 				assert.NoError(err, "Starting worker should not error")
 				assert.Equal(idle, w.status.Load(), "Status after start should be 'idle'")
 				assert.Equal("Idle", w.Status(), "Status string after start should be 'Idle'")
 				assert.True(w.IsActive(), "Worker should be running after start")
 
-				err = w.start()
+				err = w.Start()
 				assert.ErrorIs(err, ErrRunningWorker, "Starting an already running worker should error")
 
 				w.Pause()
@@ -314,16 +302,16 @@ func TestWorkers(t *testing.T) {
 				assert.True(w.IsPaused(), "Worker should be paused after Pause()")
 				assert.False(w.IsActive(), "Worker should not be running after Pause()")
 
-			err = w.Resume()
-			assert.NoError(err, "Resuming worker should not error")
-			assert.Equal(idle, w.status.Load(), "Status after resume should be 'idle'")
-			assert.Equal("Idle", w.Status(), "Status string after resume should be 'Idle'")
-			assert.True(w.IsActive(), "Worker should be running after Resume()")
+				err = w.Resume()
+				assert.NoError(err, "Resuming worker should not error")
+				assert.Equal(idle, w.status.Load(), "Status after resume should be 'idle'")
+				assert.Equal("Idle", w.Status(), "Status string after resume should be 'Idle'")
+				assert.True(w.IsActive(), "Worker should be running after Resume()")
 
-			err = w.Resume()
-			assert.NoError(err, "Resuming an already running worker should be idempotent")
+				err = w.Resume()
+				assert.NoError(err, "Resuming an already running worker should be idempotent")
 
-			w.Stop()
+				w.Stop()
 				w.WaitUntilStopped()
 				assert.Equal(stopped, w.status.Load(), "Status after stop should be 'stopped'")
 				assert.Equal("Stopped", w.Status(), "Status string after stop should be 'Stopped'")
@@ -338,53 +326,47 @@ func TestWorkers(t *testing.T) {
 			})
 
 			t.Run("restart functionality", func(t *testing.T) {
-				// Track job processing
 				var jobsProcessed atomic.Uint32
 
-				// Create a worker function that increments counter
 				workerFn := func(j iJob[int]) {
-					time.Sleep(5 * time.Millisecond) // Simulate work
+					time.Sleep(5 * time.Millisecond)
 					jobsProcessed.Add(1)
 				}
 
-				w := newWorker(workerFn)
+				w := newWorker(workerFn, WithAutoRun(false))
 				assert := assert.New(t)
 
-				// Create a queue for testing
 				q := queues.NewQueue[iJob[int]]()
 				w.queues.Register(q, math.MaxInt)
 
-				// Submit some initial jobs
+				w.Start()
+
 				for i := range 50 {
 					q.Enqueue(newJob(i, loadJobConfigs(w.configs())))
 				}
+				w.notifyToPullNextJobs()
 
-				// Start worker
-				err := w.start()
-				assert.NoError(err, "Starting worker should not error")
 				assert.True(w.IsActive(), "Worker should be running after start")
 
-				// Wait for some jobs to be processed
-				time.Sleep(50 * time.Millisecond)
+				w.Wait()
 
-				// Store the state before restart
-				processedBeforeRestart := jobsProcessed.Load()
-				assert.Greater(processedBeforeRestart, uint32(0), "Some jobs should be processed before restart")
+				assert.Equal(uint32(50), jobsProcessed.Load(), "All 50 jobs should be processed before restart")
 
-				// Restart the worker
-				err = w.Restart()
+				err := w.Restart()
 				assert.NoError(err, "Restarting worker should not error")
-
-				// Verify worker is running after restart
 				assert.True(w.IsActive(), "Worker should be running after restart")
 
-				// Wait for jobs to be processed after restart
-				time.Sleep(50 * time.Millisecond)
+				for i := range 50 {
+					q.Enqueue(newJob(i+50, loadJobConfigs(w.configs())))
+				}
+				w.notifyToPullNextJobs()
 
-				// Verify more jobs were processed after restart
-				assert.Greater(jobsProcessed.Load(), processedBeforeRestart, "More jobs should be processed after restart")
+				w.Wait()
 
-				// Clean up
+				assert.Eventually(func() bool {
+					return jobsProcessed.Load() == 100
+				}, 3*time.Second, 10*time.Millisecond, "All 100 jobs should be processed after restart")
+
 				w.Stop()
 			})
 
@@ -394,15 +376,12 @@ func TestWorkers(t *testing.T) {
 				})
 				assert := assert.New(t)
 
-				// Start and stop
-				err := w.start()
-				assert.NoError(err)
 				w.Stop()
 				w.WaitUntilStopped()
 				assert.True(w.IsStopped())
 
 				// Restart
-				err = w.Restart()
+				err := w.Restart()
 				assert.NoError(err, "Restarting a stopped worker should succeed")
 				assert.True(w.IsActive(), "Worker should be running after restart")
 
@@ -416,32 +395,27 @@ func TestWorkers(t *testing.T) {
 				})
 				assert := assert.New(t)
 
-				// Start and pause
-				err := w.start()
-				assert.NoError(err)
 				w.Pause()
 				assert.True(w.IsPaused())
 
 				// Stop
-				err = w.Stop()
+				err := w.Stop()
 				assert.NoError(err, "Stopping a paused worker should succeed")
 				w.WaitUntilStopped()
 				assert.True(w.IsStopped(), "Worker should be stopped")
 			})
 
 			t.Run("event loop processing error", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {})
+				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 				errChan := w.Errs()
 
-				// Register a mock queue that fails dequeue
 				mockQueue := mocks.NewMockPersistentQueue()
 				mockQueue.ShouldFailDequeue = true
-				// Need to put something in it to trigger the loop
 				mockQueue.Queue.Enqueue("trigger")
 
 				w.queues.Register(newQueue(w, mockQueue).internalQueue, math.MaxInt)
 
-				w.start()
+				w.Start()
 				defer w.Stop()
 
 				select {
@@ -453,22 +427,22 @@ func TestWorkers(t *testing.T) {
 			})
 
 			t.Run("redundant state transitions", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {})
+				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 				// initiated to paused: error
 				assert.ErrorIs(t, w.Pause(), ErrNotRunningWorker)
 				// initiated to stopped: error
 				assert.ErrorIs(t, w.Stop(), ErrNotRunningWorker)
 
-				w.start()
+				w.Start()
 				w.Pause()
 				assert.True(t, w.IsPaused())
 				// paused to paused: idempotent nil
 				assert.NoError(t, w.Pause())
 
-			w.Stop()
-			w.WaitUntilStopped()
-			assert.True(t, w.IsStopped())
-			// stopped to paused: error
+				w.Stop()
+				w.WaitUntilStopped()
+				assert.True(t, w.IsStopped())
+				// stopped to paused: error
 				assert.ErrorIs(t, w.Pause(), ErrWorkerStopped)
 				// stopped to stopped: idempotent nil
 				assert.NoError(t, w.Stop())
@@ -479,7 +453,6 @@ func TestWorkers(t *testing.T) {
 					w := newWorker(func(j iJob[string]) {
 						time.Sleep(10 * time.Millisecond)
 					})
-					w.start()
 					assert.NoError(t, w.Restart())
 					assert.True(t, w.IsActive())
 					w.Stop()
@@ -487,7 +460,6 @@ func TestWorkers(t *testing.T) {
 
 				t.Run("RestartPaused", func(t *testing.T) {
 					w := newWorker(func(j iJob[string]) {})
-					w.start()
 					w.Pause()
 					assert.NoError(t, w.Restart())
 					assert.True(t, w.IsActive())
@@ -533,7 +505,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("NumPending", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(10 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 				assert := assert.New(t)
 
 				// Create a queue
@@ -553,7 +525,7 @@ func TestWorkers(t *testing.T) {
 				assert.Equal(jobCount, w.NumPending(), "NumPending should reflect the number of jobs in the queue")
 
 				// Start worker to process jobs
-				err := w.start()
+				err := w.Start()
 				assert.NoError(err, "Worker should start without error")
 				defer w.Stop()
 
@@ -609,9 +581,6 @@ func TestWorkers(t *testing.T) {
 				defer w.Stop()
 				assert := assert.New(t)
 
-				err := w.start()
-				assert.NoError(err, "Starting worker should not error")
-
 				initialCount := w.pool.Len()
 				assert.Equal(initialCount, 1, "Should have one idle worker in the pool after start")
 
@@ -621,10 +590,13 @@ func TestWorkers(t *testing.T) {
 					w.pool.PushNode(node)
 				}
 
-				time.Sleep(expirySetting * 2)
-				assert.Less(w.NumIdleWorkers(), w.NumConcurrency(),
+				assert.Eventually(func() bool {
+					return w.NumIdleWorkers() < w.NumConcurrency()
+				}, expirySetting*4, 10*time.Millisecond,
 					"Number of idle workers should be reduced to less than concurrency")
-				assert.Equal(w.NumIdleWorkers(), w.numMinIdleWorkers(),
+				assert.Eventually(func() bool {
+					return w.NumIdleWorkers() == w.numMinIdleWorkers()
+				}, expirySetting*6, 10*time.Millisecond,
 					"Number of idle workers should be equal to min idle workers")
 			})
 		})
@@ -634,31 +606,25 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with IAcknowledgeable queue", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create a persistent queue that implements IAcknowledgeable
 				persistentQueue := mocks.NewMockPersistentQueue()
 				w.queues.Register(persistentQueue, math.MaxInt)
 				job := newJob("test-data", loadJobConfigs(w.configs()))
 				persistentQueue.Enqueue(job)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle queue
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
 
-				assert.Equal(t, 0, persistentQueue.Len(), "Item should be processed from queue")
+				assert.Eventually(t, func() bool { return persistentQueue.Len() == 0 }, 200*time.Millisecond, 5*time.Millisecond, "Item should be processed from queue")
 			})
 
 			t.Run("processNextJob with byte data parsing", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create a queue with byte data
 				job := newJob("test-data", loadJobConfigs(w.configs()))
 				jobBytes, _ := job.Json()
 
@@ -666,13 +632,8 @@ func TestWorkers(t *testing.T) {
 				testQueue.Enqueue(jobBytes)
 				w.queues.Register(testQueue, math.MaxInt)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle byte parsing
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Byte data should be parsed and processed")
 			})
@@ -680,9 +641,9 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with closed job", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create a closed job
 				job := newJob("test-data", loadJobConfigs(w.configs()))
 				job.Close()
 
@@ -690,13 +651,8 @@ func TestWorkers(t *testing.T) {
 				testQueue.Enqueue(job)
 				w.queues.Register(testQueue, math.MaxInt)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should skip closed job
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Closed job should be dequeued but not processed")
 			})
@@ -704,20 +660,15 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with invalid byte data", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
+				defer w.Stop()
 
-				// Create invalid byte data
 				testQueue := queues.NewQueue[any]()
 				testQueue.Enqueue([]byte("invalid json"))
 				w.queues.Register(testQueue, math.MaxInt)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle invalid byte data gracefully
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Invalid byte data should be dequeued")
 			})
@@ -725,20 +676,15 @@ func TestWorkers(t *testing.T) {
 			t.Run("processNextJob with invalid type", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
-
-				// Create invalid type data
-				testQueue := queues.NewQueue[any]()
-				testQueue.Enqueue(123) // Invalid type
-				w.queues.Register(testQueue, math.MaxInt)
-
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
+				}, WithAutoRun(false))
 				defer w.Stop()
 
-				// Process should handle invalid type gracefully
+				testQueue := queues.NewQueue[any]()
+				testQueue.Enqueue(123)
+				w.queues.Register(testQueue, math.MaxInt)
+
 				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
+				w.Wait()
 
 				assert.Equal(t, 0, testQueue.Len(), "Invalid type should be dequeued")
 			})
@@ -748,8 +694,6 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				}, WithConcurrency(1))
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Create many idle workers to trigger stopping
@@ -771,8 +715,6 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				}, WithConcurrency(5))
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Add workers to the pool
@@ -784,7 +726,7 @@ func TestWorkers(t *testing.T) {
 				initialPoolSize := w.pool.Len()
 
 				// Shrink concurrency - should trigger pool shrinking
-				err = w.TunePool(2)
+				err := w.TunePool(2)
 				assert.NoError(t, err, "TunePool should not error")
 
 				// Pool should be shrunk
@@ -794,7 +736,7 @@ func TestWorkers(t *testing.T) {
 			t.Run("Resume from initiated state returns error", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
-				})
+				}, WithAutoRun(false))
 
 				assert.Equal(t, initiated, w.status.Load(), "Worker should be in initiated state")
 
@@ -807,11 +749,9 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				})
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
-				err = w.Resume()
+				err := w.Resume()
 				assert.NoError(t, err, "Resume should be idempotent when already running")
 			})
 
@@ -820,10 +760,7 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(5 * time.Millisecond)
 				})
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-
-				err = w.Stop()
+				err := w.Stop()
 				assert.NoError(t, err, "Worker should stop without error")
 				w.WaitUntilStopped()
 
@@ -831,53 +768,11 @@ func TestWorkers(t *testing.T) {
 				assert.ErrorIs(t, err, ErrWorkerStopped, "Resume should return error when worker is stopped")
 			})
 
-			t.Run("processNextJob with empty queue", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {
-					time.Sleep(5 * time.Millisecond)
-				})
-
-				// Create an empty queue
-				testQueue := queues.NewQueue[any]()
-				w.queues.Register(testQueue, math.MaxInt)
-
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle empty queue gracefully
-				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
-			})
-
-			t.Run("processNextJob with byte parsing that creates wrong job type", func(t *testing.T) {
-				w := newWorker(func(j iJob[string]) {
-					time.Sleep(5 * time.Millisecond)
-				})
-
-				// Create a job with different type that would cause type assertion to fail
-				job := newJob(123, loadJobConfigs(w.configs())) // int instead of string
-				jobBytes, _ := job.Json()
-
-				testQueue := queues.NewQueue[any]()
-				testQueue.Enqueue(jobBytes)
-				w.queues.Register(testQueue, math.MaxInt)
-
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
-				defer w.Stop()
-
-				// Process should handle type mismatch gracefully
-				w.processNextJob()
-				time.Sleep(10 * time.Millisecond)
-			})
-
 			t.Run("TunePool edge case with empty pool", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {
 					time.Sleep(5 * time.Millisecond)
 				}, WithConcurrency(5))
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Clear the pool
@@ -888,7 +783,7 @@ func TestWorkers(t *testing.T) {
 				}
 
 				// Shrink concurrency with empty pool
-				err = w.TunePool(2)
+				err := w.TunePool(2)
 				assert.NoError(t, err, "TunePool should handle empty pool")
 			})
 
@@ -901,8 +796,6 @@ func TestWorkers(t *testing.T) {
 					WithMinIdleWorkerRatio(50),
 				)
 
-				err := w.start()
-				assert.NoError(t, err, "Worker should start without error")
 				defer w.Stop()
 
 				// Add nodes that are both in list and not in list to test edge cases
@@ -912,16 +805,12 @@ func TestWorkers(t *testing.T) {
 					w.pool.PushNode(node)
 				}
 
-				// Wait for idle worker removal to kick in
-				time.Sleep(30 * time.Millisecond)
-
-				// Should have cleaned up some workers
-				assert.LessOrEqual(t, w.pool.Len(), w.numMinIdleWorkers()+1, "Pool should be cleaned up")
+				assert.Eventually(t, func() bool { return w.pool.Len() <= w.numMinIdleWorkers()+1 }, 200*time.Millisecond, 5*time.Millisecond, "Pool should be cleaned up")
 			})
 
 			t.Run("processNextJob with parse failure", func(t *testing.T) {
 				mockQueue := mocks.NewMockPersistentQueue()
-				w := newWorker(func(j iJob[int]) {})
+				w := newWorker(func(j iJob[int]) {}, WithAutoRun(false))
 
 				mockQueue.Queue.Enqueue([]byte("invalid json"))
 
@@ -935,8 +824,7 @@ func TestWorkers(t *testing.T) {
 
 			t.Run("processNextJob with cast failure after parse", func(t *testing.T) {
 				mockQueue := mocks.NewMockPersistentQueue()
-				// use newErrWorker so JobType is iErrorJob[string]
-				w := newErrWorker(func(j iErrorJob[string]) {})
+				w := newErrWorker(func(j iErrorJob[string]) {}, WithAutoRun(false))
 
 				// Create a valid JSON that parseToJob will accept and return *job[string]
 				// *job[string] does NOT implement iErrorJob[string]
@@ -971,17 +859,11 @@ func TestWorkers(t *testing.T) {
 					time.Sleep(10 * time.Millisecond)
 				}, WithContext(ctx))
 
-				assert := assert.New(t)
-				err := w.start()
-				assert.NoError(err)
-				assert.True(w.IsActive())
+				w.WaitUntilIdle()
 
-				// Cancel the context
 				cancel()
 
-				// Wait for the worker to stop
-				time.Sleep(50 * time.Millisecond)
-				assert.True(w.IsStopped(), "Worker should be stopped after context cancellation")
+				assert.Eventually(t, func() bool { return w.IsStopped() }, 500*time.Millisecond, 5*time.Millisecond, "Worker should be stopped after context cancellation")
 			})
 
 			t.Run("restart recreates context", func(t *testing.T) {
@@ -990,13 +872,11 @@ func TestWorkers(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
 
 				assert := assert.New(t)
-				err := w.start()
-				assert.NoError(err)
 
 				// Verify context exists
 				assert.NotNil(w.Context())
 
-				err = w.Stop()
+				err := w.Stop()
 				assert.NoError(err)
 
 				err = w.Restart()
@@ -1132,9 +1012,9 @@ type mockJob struct {
 
 func TestStatusError(t *testing.T) {
 	tests := []struct {
-		name     string
-		status   status
-		wantErr  error
+		name    string
+		status  status
+		wantErr error
 	}{
 		{"paused returns ErrWorkerPaused", paused, ErrWorkerPaused},
 		{"stopped returns ErrWorkerStopped", stopped, ErrWorkerStopped},
@@ -1160,20 +1040,18 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Pause()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Pause()
 		assert.NoError(t, err)
-		assert.Equal(t, pausing, w.status.Load())
+		assert.Equal(t, pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 		err = w.Pause()
 		assert.NoError(t, err, "Pause on pausing state should be idempotent")
@@ -1187,18 +1065,16 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Stop()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Stop()
 		assert.NoError(t, err)
 		assert.Equal(t, stopping, w.status.Load())
 
@@ -1228,20 +1104,18 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Pause()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Pause()
 		assert.NoError(t, err)
-		assert.Equal(t, pausing, w.status.Load())
+		assert.Equal(t, pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 		done := make(chan struct{})
 		go func() {
@@ -1261,7 +1135,7 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		select {
 		case <-done:
 			assert.True(t, w.IsActive(), "Worker should be active after restart from pausing")
-		case <-time.After(2 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("Restart should complete after pausing completes")
 		}
 
@@ -1272,18 +1146,16 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
-		err := w.start()
-		assert.NoError(t, err)
 
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Stop()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Stop()
 		assert.NoError(t, err)
 		assert.Equal(t, stopping, w.status.Load())
 
@@ -1305,7 +1177,7 @@ func TestIdempotentStateTransitions(t *testing.T) {
 		select {
 		case <-done:
 			assert.True(t, w.IsActive(), "Worker should be active after restart from stopping")
-		case <-time.After(2 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("Restart should complete after stopping completes")
 		}
 	})
@@ -1334,10 +1206,8 @@ func (m *mockJob) Close() error {
 func TestPausePausingFastPath(t *testing.T) {
 	t.Run("Pause transitions directly to paused when no jobs processing", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
 
-		err = w.Pause()
+		err := w.Pause()
 		assert.NoError(t, err)
 		assert.Equal(t, paused, w.status.Load(), "Should transition directly to paused when idle")
 		assert.True(t, w.IsPaused())
@@ -1349,21 +1219,18 @@ func TestPausePausingFastPath(t *testing.T) {
 		blockCh := make(chan struct{})
 		w := newWorker(func(j iJob[string]) {
 			<-blockCh
-		})
+		}, WithAutoRun(false))
 		q := queues.NewQueue[iJob[string]]()
 		w.queues.Register(q, 1)
 
-		err := w.start()
-		assert.NoError(t, err)
-
 		q.Enqueue(newJob("job", loadJobConfigs(w.configs())))
-		w.notifyToPullNextJobs()
-		time.Sleep(20 * time.Millisecond)
-		assert.Greater(t, w.NumProcessing(), 0)
+		w.Start()
 
-		err = w.Pause()
+		assert.Eventually(t, func() bool { return w.NumProcessing() > 0 }, 200*time.Millisecond, 5*time.Millisecond)
+
+		err := w.Pause()
 		assert.NoError(t, err)
-		assert.Equal(t, pausing, w.status.Load(), "Should be pausing")
+		assert.Equal(t, pausing, w.status.Load(), fmt.Sprintf("Should be pausing but Got: %s", w.Status()))
 
 		close(blockCh)
 
@@ -1377,12 +1244,11 @@ func TestPausePausingFastPath(t *testing.T) {
 func TestRestartCoverage(t *testing.T) {
 	t.Run("Restart from idle with no processing", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
-		assert.True(t, w.IsIdle())
+		w.WaitUntilIdle()
 
-		err = w.Restart()
+		err := w.Restart()
 		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.True(t, w.IsActive())
 
 		w.Stop()
@@ -1390,9 +1256,8 @@ func TestRestartCoverage(t *testing.T) {
 
 	t.Run("Restart from paused", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
-		err = w.Pause()
+		w.WaitUntilIdle()
+		err := w.Pause()
 		assert.NoError(t, err)
 		assert.True(t, w.IsPaused())
 
@@ -1405,12 +1270,12 @@ func TestRestartCoverage(t *testing.T) {
 	t.Run("Restart with context cancels and recreates context", func(t *testing.T) {
 		ctx := t.Context()
 		w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
-		err := w.start()
-		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 
-		err = w.Restart()
+		err := w.Restart()
 		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 		assert.NoError(t, w.Context().Err(), "New context should not be cancelled")
 
@@ -1419,12 +1284,12 @@ func TestRestartCoverage(t *testing.T) {
 
 	t.Run("Restart without context does not panic", func(t *testing.T) {
 		w := newWorker(func(j iJob[string]) {})
-		err := w.start()
-		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 
-		err = w.Restart()
+		err := w.Restart()
 		assert.NoError(t, err)
+		w.WaitUntilIdle()
 		assert.NotNil(t, w.Context())
 
 		w.Stop()
@@ -1433,11 +1298,11 @@ func TestRestartCoverage(t *testing.T) {
 
 func TestStatusAllCases(t *testing.T) {
 	t.Run("Status returns correct string for all states", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
+		w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 
 		assert.Equal(t, "Initiated", w.Status())
 
-		w.start()
+		w.Start()
 		assert.Equal(t, "Idle", w.Status())
 
 		w.status.Store(running)
@@ -1462,7 +1327,7 @@ func TestStatusAllCases(t *testing.T) {
 
 func TestStopAndWaitErrorPath(t *testing.T) {
 	t.Run("StopAndWait returns error when Stop fails", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
+		w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 		err := w.StopAndWait()
 		assert.ErrorIs(t, err, ErrNotRunningWorker)
 	})
@@ -1472,8 +1337,6 @@ func TestReleaseWaitersCleanup(t *testing.T) {
 	t.Run("event loop performs full cleanup on context cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		w := newWorker(func(j iJob[string]) {}, WithContext(ctx))
-		err := w.start()
-		assert.NoError(t, err)
 		assert.NotNil(t, w.Context())
 
 		cancel()
@@ -1487,8 +1350,6 @@ func TestResumeConcurrency(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	})
 
-	err := w.start()
-	assert.NoError(t, err)
 	w.Pause()
 	w.WaitUntilPaused()
 	assert.True(t, w.IsPaused())
@@ -1512,14 +1373,14 @@ func TestResumeConcurrency(t *testing.T) {
 func TestStartConcurrency(t *testing.T) {
 	w := newWorker(func(j iJob[string]) {
 		time.Sleep(1 * time.Millisecond)
-	})
+	}, WithAutoRun(false))
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = w.start()
+			_ = w.Start()
 		}()
 	}
 	wg.Wait()
@@ -1534,12 +1395,10 @@ func TestRestartConcurrency(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	})
 
-	err := w.start()
-	assert.NoError(t, err)
-	assert.True(t, w.IsActive())
+	w.WaitUntilIdle()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1548,7 +1407,8 @@ func TestRestartConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.True(t, w.IsActive(), "worker should remain active after concurrent restarts")
+	w.WaitUntilIdle()
+	assert.True(t, w.IsActive(), "worker should be active after concurrent restarts")
 	w.Stop()
 	w.WaitUntilStopped()
 }


### PR DESCRIPTION
## Summary

- **Fix race conditions** in `processNextJob`, `Pause`, `Resume`, `Stop`, and `Restart` that caused flaky tests under `-race`
- **Export `Start()`** (formerly `start()`) and add **`WithAutoRun`** config option for explicit lifecycle control
- **Document** lifecycle method idempotency, error returns, and valid state coverage in the Worker interface
- **Improve tests**: replace `time.Sleep` with proper synchronization, fix goroutine leaks, rewrite flaky tests

## Commits

| # | Commit | Description |
|---|--------|-------------|
| 1 | `docs(worker)` | Document lifecycle method idempotency, errors, and valid states |
| 2 | `fix(worker)` | Close race gaps in `processNextJob`, `Pause`, `Resume`, and `Stop` |
| 3 | `fix(worker)` | Eliminate `Restart()` missed-broadcast deadlock |
| 4 | `feat(worker)` | Export `Start()`, add `WithAutoRun` config option |
| 5 | `test` | Migrate to `Start()` API and replace sleep-based waits with synchronization |

## Key Fixes

1. **`processNextJob` gap** — `curProcessing.Add(1)` + `status.CAS(idle,running)` moved before `Dequeue()`, closing the window where `Pause()` saw `status=idle` while `curProcessing>0` and transitioned directly to `paused`

2. **`Restart` deadlock** — holds `w.mx` from before `cancel()` through the wait loop, ensuring Restart is in the condvar wait queue before the event loop's final `Broadcast`

3. **`Stop` data race** — reads `w.cancel` under `w.mx` to prevent concurrent write by `Restart()`

4. **`Pause`/`Resume` missing Broadcast** — both now call `waiters.Broadcast()` on status transitions to wake sleeping `WaitUntilIdle`/`WaitUntilPaused` callers

5. **`WaitUntilIdle`** — added `curProcessing.Load() == 0` check to prevent premature return

## Verification

```
go test -race -count=15 -timeout 5m ./...
ok  	github.com/goptics/varmq	50.501s