### PR TITLE
fix(worker): resolve condition variable race conditions in waiter system

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -382,7 +382,6 @@ func (w *worker[T, JobType]) configs() configs {
 }
 
 func (w *worker[T, JobType]) releaseWaiters(processing uint32) {
-	// Early return if there's still processing happening
 	if processing != 0 {
 		return
 	}
@@ -393,7 +392,6 @@ func (w *worker[T, JobType]) releaseWaiters(processing uint32) {
 		return
 	}
 
-	// Transition from pausing to paused when done processing
 	if w.status.CompareAndSwap(pausing, paused) {
 		return
 	}
@@ -472,8 +470,10 @@ func (w *worker[T, JobType]) Errs() <-chan error {
 }
 
 func (w *worker[T, JobType]) releaseProcessingSlot() {
+	w.mx.Lock()
 	processing := w.curProcessing.Add(^uint32(0))
 	w.releaseWaiters(processing)
+	w.mx.Unlock()
 	if processing < w.concurrency.Load() {
 		w.notifyToPullNextJobs()
 	}
@@ -663,8 +663,10 @@ func (w *worker[T, JobType]) goEventLoop() {
 				w.status.Store(stopping)
 				w.Wait()
 				w.removeAllWorkers()
+				w.mx.Lock()
 				w.status.Store(stopped)
 				w.waiters.Broadcast()
+				w.mx.Unlock()
 				return
 			case <-signal:
 				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
@@ -746,21 +748,21 @@ func (w *worker[T, JobType]) NumPending() int {
 }
 
 func (w *worker[T, JobType]) Pause() error {
-	s := w.status.Load()
+	w.mx.Lock()
+	defer w.mx.Unlock()
 
+	s := w.status.Load()
 	if s == paused || s == pausing {
 		return nil
 	}
 
 	if w.status.CompareAndSwap(idle, paused) {
-		// won't Broadcast from releaseWaiters
 		w.waiters.Broadcast()
 		return nil
 	}
 
 	if w.status.CompareAndSwap(running, pausing) {
 		if w.NumProcessing() == 0 && w.status.CompareAndSwap(pausing, paused) {
-			// won't Broadcast from releaseWaiters
 			w.waiters.Broadcast()
 		}
 		return nil
@@ -771,7 +773,9 @@ func (w *worker[T, JobType]) Pause() error {
 
 func (w *worker[T, JobType]) Resume() error {
 	if w.status.CompareAndSwap(paused, idle) {
+		w.mx.Lock()
 		w.waiters.Broadcast()
+		w.mx.Unlock()
 		w.notifyToPullNextJobs()
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Fix lost wakeup: wrap status transitions + `Broadcast()` in `mx.Lock()` in event loop (`stopped`), `Pause`, and `Resume`
- Fix premature `Wait()` return: hold `mx` during `curProcessing` decrement + `releaseWaiters` in `releaseProcessingSlot`
- Fix TOCTOU in `Pause`: wrap entire Pause in `mx.Lock()` to serialize with `releaseProcessingSlot`

## Root cause

Three race conditions in the waiter system:

1. **Lost wakeup** — Status transitions + `Broadcast()` happened without `mx`, while waiters check + wait while holding `mx`. A broadcast could fire between the condition check and `sync.Cond.Wait()`, causing permanent blocking.

2. **Premature return** — `curProcessing` atomic decrement was visible to `Wait()` before `releaseWaiters` completed the status CAS. `Wait()` returned with `curProcessing=0` but status still `pausing`.

3. **TOCTOU in Pause** — `releaseWaiters` could change status between Pause's two CAS attempts (`idle→paused` and `running→pausing`), causing Pause to fail spuriously.

## Test plan

- [x] `go test -race -count=1 ./...` passes
- [x] `go test -run TestWaiters -race -count=200 -timeout 600s` — zero failures
- [x] Pre-push hook passes all tests