### PR TITLE
refactor: changed the next queue picker error flow

### DIFF
--- a/internal/helpers/manager.go
+++ b/internal/helpers/manager.go
@@ -1,16 +1,11 @@
 package helpers
 
 import (
-	"errors"
 	"reflect"
 	"slices"
 	"sync"
 )
 
-var (
-	ErrNoItemsRegistered = errors.New("no items registered")
-	ErrAllItemsEmpty     = errors.New("all items are empty")
-)
 
 // Sizer is an interface for anything that has a Len method
 type Sizer interface {
@@ -102,12 +97,12 @@ func (m *Manager[T]) Len() int {
 }
 
 // GetMaxLenItem returns the item with the maximum length
-func (m *Manager[T]) GetMaxLenItem() (T, error) {
+func (m *Manager[T]) GetMaxLenItem() (T, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
 
 	if len(m.items) == 0 {
-		return *new(T), ErrNoItemsRegistered
+		return *new(T), false
 	}
 
 	maxItem := slices.MaxFunc(m.items, func(a, b registered[T]) int {
@@ -115,19 +110,19 @@ func (m *Manager[T]) GetMaxLenItem() (T, error) {
 	})
 
 	if maxItem.item.Len() == 0 {
-		return *new(T), ErrAllItemsEmpty
+		return *new(T), false
 	}
 
-	return maxItem.item, nil
+	return maxItem.item, true
 }
 
 // GetMinLenItem returns the item with the minimum length (excluding empty items unless all are empty)
-func (m *Manager[T]) GetMinLenItem() (T, error) {
+func (m *Manager[T]) GetMinLenItem() (T, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
 
 	if len(m.items) == 0 {
-		return *new(T), ErrNoItemsRegistered
+		return *new(T), false
 	}
 
 	var minItem T
@@ -144,38 +139,38 @@ func (m *Manager[T]) GetMinLenItem() (T, error) {
 
 	// If no non-empty items found, all items are empty
 	if minLen == -1 {
-		return *new(T), ErrAllItemsEmpty
+		return *new(T), false
 	}
 
-	return minItem, nil
+	return minItem, true
 }
 
 // GetPriorityItem returns the first item with length > 0 based on priority (highest priority first).
 // Since items are inherently stored sorted by priority (lowest number first), it simply returns the first non-empty item.
-func (m *Manager[T]) GetPriorityItem() (T, error) {
+func (m *Manager[T]) GetPriorityItem() (T, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
 
 	if len(m.items) == 0 {
-		return *new(T), ErrNoItemsRegistered
+		return *new(T), false
 	}
 
 	for _, r := range m.items {
 		if r.item.Len() > 0 {
-			return r.item, nil
+			return r.item, true
 		}
 	}
 
-	return *new(T), ErrAllItemsEmpty
+	return *new(T), false
 }
 
 // GetRoundRobinItem returns the next item in round-robin order
-func (m *Manager[T]) GetRoundRobinItem() (T, error) {
+func (m *Manager[T]) GetRoundRobinItem() (T, bool) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
 	if len(m.items) == 0 {
-		return *new(T), ErrNoItemsRegistered
+		return *new(T), false
 	}
 
 	start := m.roundRobinIndex
@@ -185,11 +180,11 @@ func (m *Manager[T]) GetRoundRobinItem() (T, error) {
 		m.roundRobinIndex = (m.roundRobinIndex + 1) % len(m.items)
 
 		if r.item.Len() > 0 {
-			return r.item, nil
+			return r.item, true
 		}
 
 		if m.roundRobinIndex == start {
-			return *new(T), ErrAllItemsEmpty
+			return *new(T), false
 		}
 	}
 }

--- a/internal/helpers/manager.go
+++ b/internal/helpers/manager.go
@@ -96,7 +96,8 @@ func (m *Manager[T]) Len() int {
 	return totalLen
 }
 
-// GetMaxLenItem returns the item with the maximum length
+// GetMaxLenItem returns the item with the maximum length.
+// ok is false when no items are registered or all items are empty.
 func (m *Manager[T]) GetMaxLenItem() (T, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
@@ -116,7 +117,8 @@ func (m *Manager[T]) GetMaxLenItem() (T, bool) {
 	return maxItem.item, true
 }
 
-// GetMinLenItem returns the item with the minimum length (excluding empty items unless all are empty)
+// GetMinLenItem returns the item with the minimum length (excluding empty items unless all are empty).
+// ok is false when no items are registered or all items are empty.
 func (m *Manager[T]) GetMinLenItem() (T, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
@@ -147,6 +149,7 @@ func (m *Manager[T]) GetMinLenItem() (T, bool) {
 
 // GetPriorityItem returns the first item with length > 0 based on priority (highest priority first).
 // Since items are inherently stored sorted by priority (lowest number first), it simply returns the first non-empty item.
+// ok is false when no items are registered or all items are empty.
 func (m *Manager[T]) GetPriorityItem() (T, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
@@ -164,7 +167,8 @@ func (m *Manager[T]) GetPriorityItem() (T, bool) {
 	return *new(T), false
 }
 
-// GetRoundRobinItem returns the next item in round-robin order
+// GetRoundRobinItem returns the next item in round-robin order.
+// ok is false when no items are registered or all items are empty.
 func (m *Manager[T]) GetRoundRobinItem() (T, bool) {
 	m.mx.Lock()
 	defer m.mx.Unlock()

--- a/internal/helpers/manager_test.go
+++ b/internal/helpers/manager_test.go
@@ -59,13 +59,13 @@ func TestManager(t *testing.T) {
 			item3 := &testItem{id: "item3", len: 3}
 
 			// No items
-			_, err := manager.GetRoundRobinItem()
-			assert.Equal(ErrNoItemsRegistered, err)
+			_, ok := manager.GetRoundRobinItem()
+			assert.False(ok)
 
 			// Register & test order
 			manager.Register(item1, math.MaxInt)
-			res, err := manager.GetRoundRobinItem()
-			assert.NoError(err)
+			res, ok := manager.GetRoundRobinItem()
+			assert.True(ok)
 			assert.Equal(item1, res)
 
 			manager.Register(item2, math.MaxInt)
@@ -100,13 +100,13 @@ func TestManager(t *testing.T) {
 			assert.Equal(2, manager.Count())
 
 			// After unregister, next call should not error and should return a according to current logic
-			res, err := manager.GetRoundRobinItem()
-			assert.NoError(err)
+			res, ok := manager.GetRoundRobinItem()
+			assert.True(ok)
 			assert.Equal(a, res)
 
 			// Following call should return c (the remaining item)
-			res, err = manager.GetRoundRobinItem()
-			assert.NoError(err)
+			res, ok = manager.GetRoundRobinItem()
+			assert.True(ok)
 			assert.Equal(c, res)
 		})
 
@@ -118,16 +118,16 @@ func TestManager(t *testing.T) {
 			item3 := &testItem{id: "item3", len: 2}
 			item4 := &testItem{id: "item4", len: 7}
 
-			_, err := manager.GetMaxLenItem()
-			assert.Equal(ErrNoItemsRegistered, err)
+			_, ok := manager.GetMaxLenItem()
+			assert.False(ok)
 
 			manager.Register(item1, math.MaxInt)
 			manager.Register(item2, math.MaxInt)
 			manager.Register(item3, math.MaxInt)
 			manager.Register(item4, math.MaxInt)
 
-			res, err := manager.GetMaxLenItem()
-			assert.NoError(err)
+			res, ok := manager.GetMaxLenItem()
+			assert.True(ok)
 			assert.Equal(item4, res)
 		})
 
@@ -139,8 +139,8 @@ func TestManager(t *testing.T) {
 			item3 := &testItem{id: "item3", len: 2}
 			item4 := &testItem{id: "item4", len: 0}
 
-			_, err := manager.GetMinLenItem()
-			assert.Equal(ErrNoItemsRegistered, err)
+			_, ok := manager.GetMinLenItem()
+			assert.False(ok)
 
 			manager.Register(item1, math.MaxInt)
 			manager.Register(item2, math.MaxInt)
@@ -161,61 +161,61 @@ func TestManager(t *testing.T) {
 			item3 := &testItem{id: "item3", len: 0} // highest priority but empty
 			item4 := &testItem{id: "item4", len: 4} // high priority
 
-			_, err := manager.GetPriorityItem()
-			assert.Equal(ErrNoItemsRegistered, err)
+			_, ok := manager.GetPriorityItem()
+			assert.False(ok)
 
 			manager.Register(item1, 10) // priority 10
 			manager.Register(item2, 5)  // priority 5
 
-			res, err := manager.GetPriorityItem()
-			assert.NoError(err)
+			res, ok := manager.GetPriorityItem()
+			assert.True(ok)
 			assert.Equal(item2, res) // Returns highest priority item with Len > 0 (item2 with priority 5)
 
 			manager.Register(item3, 1) // priority 1
 
-			res, err = manager.GetPriorityItem()
-			assert.NoError(err)
+			res, ok = manager.GetPriorityItem()
+			assert.True(ok)
 			assert.Equal(item2, res) // item3 is empty, so should still return item2
 
 			manager.Register(item4, 3) // priority 3
 
-			res, err = manager.GetPriorityItem()
-			assert.NoError(err)
+			res, ok = manager.GetPriorityItem()
+			assert.True(ok)
 			assert.Equal(item4, res) // Returns item4 as it has higher priority (3) than item2 (5)
 		})
 
-		// All methods should return ErrAllItemsEmpty when only zero-length items are registered
+		// All methods should return false when only zero-length items are registered
 		t.Run("AllItemsEmpty", func(t *testing.T) {
 			assert := assert.New(t)
 			manager := NewManager[*testItem]()
 			manager.Register(&testItem{id: "e1", len: 0}, math.MaxInt)
 			manager.Register(&testItem{id: "e2", len: 0}, math.MaxInt)
 
-			_, err := manager.GetRoundRobinItem()
-			assert.Equal(ErrAllItemsEmpty, err)
+			_, ok := manager.GetRoundRobinItem()
+			assert.False(ok)
 
-			_, err = manager.GetMaxLenItem()
-			assert.Equal(ErrAllItemsEmpty, err)
+			_, ok = manager.GetMaxLenItem()
+			assert.False(ok)
 
-			_, err = manager.GetMinLenItem()
-			assert.Equal(ErrAllItemsEmpty, err)
+			_, ok = manager.GetMinLenItem()
+			assert.False(ok)
 
-			_, err = manager.GetPriorityItem()
-			assert.Equal(ErrAllItemsEmpty, err)
+			_, ok = manager.GetPriorityItem()
+			assert.False(ok)
 		})
 	})
 
 	t.Run("EmptyManager", func(t *testing.T) {
 		assert := assert.New(t)
 		manager := NewManager[*testItem]()
-		_, err := manager.GetRoundRobinItem()
-		assert.Equal(ErrNoItemsRegistered, err)
-		_, err = manager.GetMaxLenItem()
-		assert.Equal(ErrNoItemsRegistered, err)
-		_, err = manager.GetMinLenItem()
-		assert.Equal(ErrNoItemsRegistered, err)
-		_, err = manager.GetPriorityItem()
-		assert.Equal(ErrNoItemsRegistered, err)
+		_, ok := manager.GetRoundRobinItem()
+		assert.False(ok)
+		_, ok = manager.GetMaxLenItem()
+		assert.False(ok)
+		_, ok = manager.GetMinLenItem()
+		assert.False(ok)
+		_, ok = manager.GetPriorityItem()
+		assert.False(ok)
 	})
 
 	t.Run("ConcurrentOperations", func(t *testing.T) {
@@ -225,7 +225,6 @@ func TestManager(t *testing.T) {
 		manager.Register(&testItem{id: "item2", len: 5}, math.MaxInt)
 
 		var wg sync.WaitGroup
-		errChan := make(chan error, 30)
 		for i := range 10 {
 			wg.Add(3)
 			go func(id int) {
@@ -234,22 +233,14 @@ func TestManager(t *testing.T) {
 			}(i)
 			go func() {
 				defer wg.Done()
-				if _, err := manager.GetRoundRobinItem(); err != nil && err != ErrNoItemsRegistered && err != ErrAllItemsEmpty {
-					errChan <- err
-				}
+				manager.GetRoundRobinItem()
 			}()
 			go func() {
 				defer wg.Done()
-				if _, err := manager.GetMaxLenItem(); err != nil && err != ErrNoItemsRegistered && err != ErrAllItemsEmpty {
-					errChan <- err
-				}
+				manager.GetMaxLenItem()
 			}()
 		}
 		wg.Wait()
-		close(errChan)
-		for err := range errChan {
-			assert.NoError(err)
-		}
 		assert.Greater(manager.Count(), 2)
 	})
 
@@ -272,28 +263,28 @@ func TestManager(t *testing.T) {
 		// Order should be: high, high2, medium, low
 		assert.Equal(4, manager.Count())
 
-		res, err := manager.GetRoundRobinItem()
-		assert.NoError(err)
+		res, ok := manager.GetRoundRobinItem()
+		assert.True(ok)
 		assert.Equal(itemHigh, res)
 
-		res, err = manager.GetRoundRobinItem()
-		assert.NoError(err)
+		res, ok = manager.GetRoundRobinItem()
+		assert.True(ok)
 		assert.Equal(itemHigh2, res)
 
-		res, err = manager.GetRoundRobinItem()
-		assert.NoError(err)
+		res, ok = manager.GetRoundRobinItem()
+		assert.True(ok)
 		assert.Equal(itemMedium, res)
 
-		res, err = manager.GetRoundRobinItem()
-		assert.NoError(err)
+		res, ok = manager.GetRoundRobinItem()
+		assert.True(ok)
 		assert.Equal(itemLow, res)
 
 		// Unregistering item should maintain order of the rest
 		manager.UnregisterItem(itemMedium)
 
 		// Next item was index 0 (high)
-		res, err = manager.GetRoundRobinItem()
-		assert.NoError(err)
+		res, ok = manager.GetRoundRobinItem()
+		assert.True(ok)
 		assert.Equal(itemHigh, res)
 	})
 }

--- a/internal/helpers/manager_test.go
+++ b/internal/helpers/manager_test.go
@@ -233,11 +233,13 @@ func TestManager(t *testing.T) {
 			}(i)
 			go func() {
 				defer wg.Done()
-				manager.GetRoundRobinItem()
+				_, ok := manager.GetRoundRobinItem()
+				assert.True(ok)
 			}()
 			go func() {
 				defer wg.Done()
-				manager.GetMaxLenItem()
+				_, ok := manager.GetMaxLenItem()
+				assert.True(ok)
 			}()
 		}
 		wg.Wait()

--- a/queue_manager.go
+++ b/queue_manager.go
@@ -31,7 +31,7 @@ func newQueueManager(strategy Strategy) *queueManager {
 	}
 }
 
-func (qm *queueManager) next() (IBaseQueue, error) {
+func (qm *queueManager) next() (IBaseQueue, bool) {
 	switch qm.strategy {
 	case RoundRobin:
 		return qm.GetRoundRobinItem()

--- a/queue_manager_test.go
+++ b/queue_manager_test.go
@@ -28,21 +28,21 @@ func TestQueueManagerNext(t *testing.T) {
 		qm.Register(q3, math.MaxInt)
 
 		// Test round-robin behavior
-		queue1, err := qm.next()
-		assert.NoError(t, err)
+		queue1, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue1)
 
-		queue2, err := qm.next()
-		assert.NoError(t, err)
+		queue2, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue2)
 
-		queue3, err := qm.next()
-		assert.NoError(t, err)
+		queue3, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue3)
 
 		// Fourth call should cycle back to first queue
-		queue4, err := qm.next()
-		assert.NoError(t, err)
+		queue4, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue4)
 
 		// Order should be maintained in round-robin
@@ -72,8 +72,8 @@ func TestQueueManagerNext(t *testing.T) {
 		qm.Register(q3, math.MaxInt)
 
 		// MaxLen should always return the queue with the most items
-		queue, err := qm.next()
-		assert.NoError(t, err)
+		queue, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue)
 		assert.Equal(t, 3, queue.Len(), "MaxLen strategy should return queue with the most items")
 		assert.Equal(t, q3, queue, "MaxLen strategy should return q3 with 3 items")
@@ -100,8 +100,8 @@ func TestQueueManagerNext(t *testing.T) {
 		qm.Register(q3, math.MaxInt)
 
 		// MinLen should always return the queue with the fewest items
-		queue, err := qm.next()
-		assert.NoError(t, err)
+		queue, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue)
 		assert.Equal(t, 1, queue.Len(), "MinLen strategy should return queue with the fewest items")
 		assert.Equal(t, q1, queue, "MinLen strategy should return q1 with 1 item")
@@ -127,16 +127,16 @@ func TestQueueManagerNext(t *testing.T) {
 		qm.Register(q3, 1)
 
 		// Priority should always return the queue with the highest priority first, provided it has items
-		queue, err := qm.next()
-		assert.NoError(t, err)
+		queue, ok := qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue)
 		assert.Equal(t, q3, queue, "Priority strategy should return q3 with highest priority 1")
 
 		// Remove q3 to test falling back to next highest priority
 		qm.UnregisterItem(q3)
 
-		queue, err = qm.next()
-		assert.NoError(t, err)
+		queue, ok = qm.next()
+		assert.True(t, ok)
 		assert.NotNil(t, queue)
 		assert.Equal(t, q2, queue, "Priority strategy should return q2 with priority 5 after q3 is unregistered")
 	})
@@ -147,10 +147,9 @@ func TestQueueManagerNext(t *testing.T) {
 
 		for _, strategy := range strategies {
 			qm := newQueueManager(strategy)
-			queue, err := qm.next()
-			assert.Error(t, err, "Should return error when no queues are registered")
+			queue, ok := qm.next()
+			assert.False(t, ok, "Should return false when no queues are registered")
 			assert.Nil(t, queue, "Should return nil queue when no queues are registered")
-			assert.Equal(t, "no items registered", err.Error(), "Error message should indicate no items registered")
 		}
 	})
 
@@ -162,10 +161,9 @@ func TestQueueManagerNext(t *testing.T) {
 		q := queues.NewQueue[any]()
 		qm.Register(q, math.MaxInt)
 
-		// Since no items are in the queue, next() returns ErrAllItemsEmpty via Priority fallback.
-		queue, err := qm.next()
-		assert.Error(t, err, "Should return error when queue is empty")
+		// Since no items are in the queue, next() returns false via Priority fallback.
+		queue, ok := qm.next()
+		assert.False(t, ok, "Should return false when queue is empty")
 		assert.Nil(t, queue, "Should return nil queue when queue is empty")
-		assert.Equal(t, "all items are empty", err.Error(), "Error message should indicate empty queue")
 	})
 }

--- a/worker.go
+++ b/worker.go
@@ -26,7 +26,6 @@ var (
 	ErrSameConcurrency  = errors.New("worker already has the same concurrency")
 	ErrFailedToDequeue  = errors.New("failed to dequeue job")
 	ErrFailedToCastJob  = errors.New("failed to cast job")
-	ErrGetNextQueue     = errors.New("failed to get next queue")
 	ErrParseJob         = errors.New("failed to parse job")
 )
 

--- a/worker_eventloop.go
+++ b/worker_eventloop.go
@@ -21,8 +21,12 @@ func (w *worker[T, JobType]) goEventLoop() {
 				return
 			case <-signal:
 				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
-					if err := w.processNextJob(); err != nil {
+					cont, err := w.processNextJob()
+					if err != nil {
 						w.sendError(err)
+					}
+					if !cont {
+						break
 					}
 				}
 			}
@@ -30,11 +34,11 @@ func (w *worker[T, JobType]) goEventLoop() {
 	}(w.ctx, w.eventLoopSignal)
 }
 
-func (w *worker[T, JobType]) processNextJob() error {
+func (w *worker[T, JobType]) processNextJob() (bool, error) {
 	queue, found := w.queues.next()
 
 	if !found {
-		return nil
+		return false, nil
 	}
 
 	w.curProcessing.Add(1)
@@ -55,7 +59,7 @@ func (w *worker[T, JobType]) processNextJob() error {
 
 	if !ok {
 		w.releaseProcessingSlot()
-		return ErrFailedToDequeue
+		return true, ErrFailedToDequeue
 	}
 
 	var j JobType
@@ -67,23 +71,23 @@ func (w *worker[T, JobType]) processNextJob() error {
 		var err error
 		if v, err = parseToJob[T](value); err != nil {
 			w.releaseProcessingSlot()
-			return err
+			return true, err
 		}
 
 		if j, ok = v.(JobType); !ok {
 			w.releaseProcessingSlot()
-			return ErrFailedToCastJob
+			return true, ErrFailedToCastJob
 		}
 
 		j.setInternalQueue(queue)
 	default:
 		w.releaseProcessingSlot()
-		return ErrFailedToCastJob
+		return true, ErrFailedToCastJob
 	}
 
 	if j.IsClosed() {
 		w.releaseProcessingSlot()
-		return nil
+		return true, nil
 	}
 
 	j.changeStatus(processing)
@@ -91,7 +95,7 @@ func (w *worker[T, JobType]) processNextJob() error {
 
 	w.sendToNextChannel(j)
 
-	return nil
+	return true, nil
 }
 
 func (w *worker[T, JobType]) releaseProcessingSlot() {

--- a/worker_eventloop.go
+++ b/worker_eventloop.go
@@ -2,7 +2,6 @@ package varmq
 
 import (
 	"context"
-	"errors"
 	"time"
 )
 
@@ -23,9 +22,6 @@ func (w *worker[T, JobType]) goEventLoop() {
 			case <-signal:
 				for w.IsActive() && w.curProcessing.Load() < w.concurrency.Load() && w.queues.Len() > 0 {
 					if err := w.processNextJob(); err != nil {
-						if errors.Is(err, ErrGetNextQueue) {
-							break
-						}
 						w.sendError(err)
 					}
 				}
@@ -35,10 +31,10 @@ func (w *worker[T, JobType]) goEventLoop() {
 }
 
 func (w *worker[T, JobType]) processNextJob() error {
-	queue, err := w.queues.next()
+	queue, found := w.queues.next()
 
-	if err != nil {
-		return ErrGetNextQueue
+	if !found {
+		return nil
 	}
 
 	w.curProcessing.Add(1)

--- a/worker_test.go
+++ b/worker_test.go
@@ -938,21 +938,6 @@ func TestWorkers(t *testing.T) {
 	})
 }
 
-func TestPublicWorkerErrors(t *testing.T) {
-	t.Run("ErrGetNextQueue can be detected with errors.Is", func(t *testing.T) {
-		w := newWorker(func(j iJob[string]) {})
-		defer w.StopAndWait()
-
-		// Register an empty queue so next() returns ErrAllItemsEmpty,
-		// which processNextJob returns as ErrGetNextQueue.
-		mockQueue := mocks.NewMockPersistentQueue()
-		w.queues.Register(mockQueue, math.MaxInt)
-
-		err := w.processNextJob()
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, ErrGetNextQueue, "should return ErrGetNextQueue sentinel")
-	})
-}
 
 type mockJob struct {
 	*job[string]

--- a/worker_test.go
+++ b/worker_test.go
@@ -813,9 +813,21 @@ func TestWorkers(t *testing.T) {
 				queue := newErrorQueue(w, mockQueue)
 				w.queues.Register(queue.internalQueue, math.MaxInt)
 
-				err := w.processNextJob()
+				_, err := w.processNextJob()
 				assert.Error(t, err)
 				assert.Equal(t, ErrFailedToCastJob, err)
+			})
+
+			t.Run("processNextJob returns false when all queues empty", func(t *testing.T) {
+				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
+				defer w.StopAndWait()
+
+				mockQueue := mocks.NewMockPersistentQueue()
+				w.queues.Register(mockQueue, math.MaxInt)
+
+				cont, err := w.processNextJob()
+				assert.False(t, cont)
+				assert.NoError(t, err)
 			})
 		})
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -415,6 +415,20 @@ func TestWorkers(t *testing.T) {
 				assert.True(w.IsStopped(), "Worker should be stopped")
 			})
 
+			t.Run("event loop stops when no eligible queue", func(t *testing.T) {
+				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
+				w.queues.Register(&lenDriftQueue{}, math.MaxInt)
+
+				w.Start()
+				defer w.StopAndWait()
+
+				w.notifyToPullNextJobs()
+
+				assert.Eventually(t, func() bool {
+					return w.IsActive() && w.curProcessing.Load() == 0
+				}, 200*time.Millisecond, 5*time.Millisecond, "event loop should break without spinning")
+			})
+
 			t.Run("event loop processing error", func(t *testing.T) {
 				w := newWorker(func(j iJob[string]) {}, WithAutoRun(false))
 				errChan := w.Errs()
@@ -950,6 +964,23 @@ func TestWorkers(t *testing.T) {
 	})
 }
 
+
+// ponytail: Len() reports 1 once so Manager.Len() enters the pull loop, then 0 so next() returns !found
+type lenDriftQueue struct {
+	lenCalls atomic.Int32
+}
+
+func (q *lenDriftQueue) Len() int {
+	if q.lenCalls.Add(1) == 1 {
+		return 1
+	}
+	return 0
+}
+
+func (q *lenDriftQueue) Dequeue() (any, bool) { return nil, false }
+func (q *lenDriftQueue) Values() []any        { return nil }
+func (q *lenDriftQueue) Purge()               {}
+func (q *lenDriftQueue) Close() error         { return nil }
 
 type mockJob struct {
 	*job[string]


### PR DESCRIPTION
Queue selection helpers and queueManager.next() now return (T, bool) instead of (T, error). The two sentinel errors (ErrNoItemsRegistered, ErrAllItemsEmpty) carried no actionable information for callers — a simple ok/found bool is more idiomatic Go for a "found or not" lookup.

- internal/helpers/manager.go: remove sentinel error vars and errors import; all four Get*Item functions return (T, bool)
- queue_manager.go: next() returns (IBaseQueue, bool)
- worker_eventloop.go: processNextJob uses found bool, returns nil on !found; removes now-unreachable ErrGetNextQueue break branch and errors import
- worker.go: remove exported ErrGetNextQueue sentinel
- *_test.go: update assertions to assert.True/False(ok), remove TestPublicWorkerErrors which tested the deleted sentinel


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Checklist

- [ ] Self-reviewed
- [ ] Tests added/updated
- [ ] Documentation updated

## Related Issues

Fixes #
