### PR TITLE
ci: run tests only on Go file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,17 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - ".gitignore"
-      - "docs/**"
-      - "assets/**"
-      - "LICENSE"
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - ".gitignore"
-      - "docs/**"
-      - "assets/**"
-      - "LICENSE"
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
 
 jobs:
   test:

--- a/.github/workflows/deploy-bench-log.yml
+++ b/.github/workflows/deploy-bench-log.yml
@@ -38,7 +38,7 @@ jobs:
           merge-dir: prev-merged.json
           group-pattern: n/y
           name: "VarMQ Benchmark Log"
-          scale: log
+          charts: line,pie
           tag-axis: x
           output-json: merged.json
           output-html: pages/bench-log/index.html

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,4 +31,5 @@ pre-commit:
 pre-push:
   commands:
     run-tests:
+      glob: "{**/*.go,go.mod,go.sum}"
       run: go test -race -count=1 ./...


### PR DESCRIPTION
## Summary

- **lefthook**: added `glob: "{**/*.go,go.mod,go.sum}"` to `run-tests` — skips test run on doc/asset-only pushes
- **ci.yml**: replaced `paths-ignore` blocklist with `paths` allowlist (`**/*.go`, `go.mod`, `go.sum`) — CI only triggers on Go source/module changes
- **deploy-bench-log.yml**: replaced `scale: log` with `charts: line,pie`
